### PR TITLE
nsenter: fix setns() for rhel6 (glibc-2.12)

### DIFF
--- a/namespaces/nsenter.go
+++ b/namespaces/nsenter.go
@@ -49,6 +49,16 @@ void get_args(int *argc, char ***argv) {
 	(*argv)[*argc] = NULL;
 }
 
+// Use raw setns syscall for versions of glibc that don't include it (namely glibc-2.12)
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 14 && defined(SYS_setns)
+#define _GNU_SOURCE
+#include <sched.h>
+#include "syscall.h"
+int setns(int fd, int nstype) {
+  return syscall(SYS_setns, fd, nstype);
+}
+#endif
+
 void nsenter() {
 	int argc;
 	char **argv;


### PR DESCRIPTION
Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
