### PR TITLE
Fix invalid fd race

### DIFF
--- a/namespaces/init.go
+++ b/namespaces/init.go
@@ -185,7 +185,10 @@ func setupRoute(container *libcontainer.Container) error {
 // and working dir, and closes any leaky file descriptors
 // before execing the command inside the namespace
 func FinalizeNamespace(container *libcontainer.Container) error {
-	if err := system.CloseFdsFrom(3); err != nil {
+	// Ensure that all non-standard fds we may have accidentally
+	// inherited are marked close-on-exec so they stay out of the
+	// container
+	if err := utils.CloseExecFrom(3); err != nil {
 		return fmt.Errorf("close open file descriptors %s", err)
 	}
 
@@ -217,6 +220,7 @@ func FinalizeNamespace(container *libcontainer.Container) error {
 			return fmt.Errorf("chdir to %s %s", container.WorkingDir, err)
 		}
 	}
+
 	return nil
 }
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -4,7 +4,10 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"io"
+	"io/ioutil"
 	"path/filepath"
+	"strconv"
+	"syscall"
 )
 
 // GenerateRandomName returns a new name joined with a prefix.  This size
@@ -25,4 +28,28 @@ func ResolveRootfs(uncleanRootfs string) (string, error) {
 		return "", err
 	}
 	return filepath.EvalSymlinks(rootfs)
+}
+
+func CloseExecFrom(minFd int) error {
+	fdList, err := ioutil.ReadDir("/proc/self/fd")
+	if err != nil {
+		return err
+	}
+	for _, fi := range fdList {
+		fd, err := strconv.Atoi(fi.Name())
+		if err != nil {
+			// ignore non-numeric file names
+			continue
+		}
+
+		if fd < minFd {
+			// ignore descriptors lower than our specified minimum
+			continue
+		}
+
+		// intentionally ignore errors from syscall.CloseOnExec
+		syscall.CloseOnExec(fd)
+		// the cases where this might fail are basically file descriptors that have already been closed (including and especially the one that was created when ioutil.ReadDir did the "opendir" syscall)
+	}
+	return nil
 }


### PR DESCRIPTION
Sometimes I was getting:

2014/06/13 13:47:24 finalize namespace drop bounding set read /proc/1/status: bad file descriptor

This happens when applying the capabilities, and the code that
reads the current caps opens /proc/1/status and then reads some data from it.
But during this it gets a EBADFD error.

The problem is that FinalizeNamespace() closes all FDs before applying
the caps, and if a GC then happens after /proc/1/status is opened but
before reading from the fd, then an old os.File finalizer may close the
already closed-and-reused fd, wreaking havoc.

We fix this by running the GC before closing all the FDs to avoid
the risk of this happening to later os.File users, as well as
moving the fd closing to the after setting the capabilities.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
