### PR TITLE
nsenter: fixing the cpp order

### DIFF
--- a/namespaces/nsenter.go
+++ b/namespaces/nsenter.go
@@ -52,13 +52,15 @@ void get_args(int *argc, char ***argv) {
 }
 
 // Use raw setns syscall for versions of glibc that don't include it (namely glibc-2.12)
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 14 && defined(SYS_setns)
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 14
 #define _GNU_SOURCE
 #include <sched.h>
 #include "syscall.h"
+#ifdef SYS_setns
 int setns(int fd, int nstype) {
   return syscall(SYS_setns, fd, nstype);
 }
+#endif
 #endif
 
 void nsenter() {


### PR DESCRIPTION
sorry for the noise, but I had my pre-processor bits out of order

Docker-DCO-1.1-Signed-off-by: Vincent Batts vbatts@redhat.com (github: vbatts)
