### PR TITLE
Report child error better (and later)

### DIFF
--- a/namespaces/sync_pipe.go
+++ b/namespaces/sync_pipe.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"syscall"
 
 	"github.com/docker/libcontainer"
 )
@@ -18,10 +19,14 @@ type SyncPipe struct {
 
 func NewSyncPipe() (s *SyncPipe, err error) {
 	s = &SyncPipe{}
-	s.child, s.parent, err = os.Pipe()
+
+	fds, err := syscall.Socketpair(syscall.AF_LOCAL, syscall.SOCK_STREAM|syscall.SOCK_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
+	s.child = os.NewFile(uintptr(fds[0]), "child syncpipe")
+	s.parent = os.NewFile(uintptr(fds[1]), "parent syncpipe")
+
 	return s, nil
 }
 
@@ -51,6 +56,18 @@ func (s *SyncPipe) SendToChild(context libcontainer.Context) error {
 		return err
 	}
 	s.parent.Write(data)
+	syscall.Shutdown(int(s.parent.Fd()), syscall.SHUT_WR)
+	return nil
+}
+
+func (s *SyncPipe) BlockOnChild() error {
+	data, err := ioutil.ReadAll(s.parent)
+	if err != nil {
+		return nil
+	}
+	if len(data) > 0 {
+		return fmt.Errorf("Child error: %s", string(data))
+	}
 	return nil
 }
 
@@ -69,6 +86,11 @@ func (s *SyncPipe) ReadFromParent() (libcontainer.Context, error) {
 
 }
 
+func (s *SyncPipe) ReportError(err error) {
+	s.child.Write([]byte(err.Error()))
+	s.CloseChild()
+}
+
 func (s *SyncPipe) Close() error {
 	if s.parent != nil {
 		s.parent.Close()
@@ -77,4 +99,11 @@ func (s *SyncPipe) Close() error {
 		s.child.Close()
 	}
 	return nil
+}
+
+func (s *SyncPipe) CloseChild() {
+	if s.child != nil {
+		s.child.Close()
+		s.child = nil
+	}
 }


### PR DESCRIPTION
We use a unix domain socketpair instead of a pipe for the sync pipe,
which allows us to use two-way shutdown. After sending the
context we shut down the write side which lets the child know
it finished reading.

We then block on a read in the parent for the child closing the file
(ensuring we close our version of it too) to sync for when the child
is finished initializing. If the read is non-empty we assume this
is an error report and fail with an error. Otherwise we continue as
before.

This also means we're now calling back the start callback later,
meaning at that point its more likely to have succeeded, as well as
having consumed all the container resources (like volume mounts,
making it safe to e.g. unmount them when the start callback is
called).

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
