### PR TITLE
Allow caller to change the SELinux labels on a directory tree.

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -18,6 +18,10 @@ func SetFileLabel(path string, fileLabel string) error {
 	return nil
 }
 
+func Relabel(path string, fileLabel string, relabel string) error {
+	return nil
+}
+
 func GetPidCon(pid int) (string, error) {
 	return "", nil
 }

--- a/label/label_selinux.go
+++ b/label/label_selinux.go
@@ -66,6 +66,23 @@ func SetFileLabel(path string, fileLabel string) error {
 	return nil
 }
 
+// Change the label of path to the filelabel string.  If the relabel string
+// is "z", relabel will change the MCS label to s0.  This will allow all
+// containers to share the content.  If the relabel string is a "Z" then
+// the MCS label should continue to be used.  SELinux will use this field
+// to make sure the content can not be shared by other containes.
+func Relabel(path string, fileLabel string, relabel string) error {
+	if fileLabel == "" {
+		return nil
+	}
+	if relabel == "z" {
+		c := selinux.NewContext(fileLabel)
+		c["level"] = "s0"
+		fileLabel = c.Get()
+	}
+	return selinux.Chcon(path, fileLabel, true)
+}
+
 func GetPidCon(pid int) (string, error) {
 	if !selinux.SelinuxEnabled() {
 		return "", nil

--- a/mount/types.go
+++ b/mount/types.go
@@ -30,6 +30,7 @@ type Mount struct {
 	Source      string `json:"source,omitempty"`      // Source path, in the host namespace
 	Destination string `json:"destination,omitempty"` // Destination path, in the container
 	Writable    bool   `json:"writable,omitempty"`
+	Relabel     string `json:"relabel,omitempty"` // Relabel source if set, "z" indicates shared, "Z" indicates unshared
 	Private     bool   `json:"private,omitempty"`
 }
 


### PR DESCRIPTION
We want to add this to libcontainer so that we can change docker so that when you volume mount into a labeled container, we want to allow the administrator/user the ability to tell docker to fix the labels on the mount.

This pull request is split out from the pull request for docker

https://github.com/dotcloud/docker/pull/5910

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
