### PR TITLE
[Alternative]: Add User Namespace support to libcontainer.

### DIFF
--- a/container.go
+++ b/container.go
@@ -62,6 +62,12 @@ type Config struct {
 	// RestrictSys will remount /proc/sys, /sys, and mask over sysrq-trigger as well as /proc/irq and
 	// /proc/bus
 	RestrictSys bool `json:"restrict_sys,omitempty"`
+
+	// UidMappings is a string array of uid mappings for user namespaces
+	UidMappings []IdMap `json:"uid_mappings,omitempty"`
+
+	// GidMappings is a string array of gid mappings for user namespaces
+	GidMappings []IdMap `json:"gid_mappings,omitempty"`
 }
 
 // Routes can be specified to create entries in the route table as the container is started
@@ -83,4 +89,11 @@ type Route struct {
 
 	// The device to set this route up for, for example: eth0
 	InterfaceName string `json:"interface_name,omitempty"`
+}
+
+// This represents a UidMapping/GidMapping for User Namespaces.
+type IdMap struct {
+	ContainerId uint32 `json:"container_id,omitempty"`
+	HostId      uint32 `json:"host_id,omitempty"`
+	Size        uint32 `json:"size,omitempty"`
 }

--- a/namespaces/exec.go
+++ b/namespaces/exec.go
@@ -183,6 +183,11 @@ func InitializeNetworking(container *libcontainer.Config, nspid int, pipe *SyncP
 // flags on clone, unshare, and setns
 func GetNamespaceFlags(namespaces map[string]bool) (flag int) {
 	for key, enabled := range namespaces {
+		// We cannot clone into new user namespace at the same time as
+		// other namespaces.
+		if key == "NEWUSER" {
+			continue
+		}
 		if enabled {
 			if ns := GetNamespace(key); ns != nil {
 				flag |= ns.Value

--- a/namespaces/init.go
+++ b/namespaces/init.go
@@ -2,12 +2,20 @@
 
 package namespaces
 
+/*
+#include <linux/securebits.h>
+*/
+import "C"
+
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"syscall"
+	"unsafe"
 
 	"github.com/docker/libcontainer"
 	"github.com/docker/libcontainer/apparmor"
@@ -102,6 +110,16 @@ func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, syn
 		}
 	}
 
+	userNsEnabled := container.Namespaces["NEWUSER"]
+	if userNsEnabled {
+		return execUserNs(container, args)
+	} else {
+		return execDefault(container, args)
+	}
+}
+
+// Init continues execution for non-userns case in this function.
+func execDefault(container *libcontainer.Config, args []string) error {
 	pdeathSignal, err := system.GetParentDeathSignal()
 	if err != nil {
 		return fmt.Errorf("get parent death signal %s", err)
@@ -111,13 +129,229 @@ func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, syn
 		return fmt.Errorf("finalize namespace %s", err)
 	}
 
-	// FinalizeNamespace can change user/group which clears the parent death
+	// Changing user/group clears the parent death
 	// signal, so we restore it here.
 	if err := RestoreParentDeathSignal(pdeathSignal); err != nil {
 		return fmt.Errorf("restore parent death signal %s", err)
 	}
 
 	return system.Execv(args[0], args[0:], container.Env)
+}
+
+// Get the corresponding hostId for a containerId if specified in the IdMap
+func hostIdFromMapping(containerId uint32, idMap []libcontainer.IdMap) (uint32, bool) {
+	for _, m := range idMap {
+		if (containerId >= m.ContainerId) && (containerId <= (m.ContainerId + m.Size - 1)) {
+			hostId := m.HostId + (containerId - m.ContainerId)
+			return hostId, true
+		}
+	}
+	return 0, false
+}
+
+// Init continues execution for userns case in this function.
+func execUserNs(container *libcontainer.Config, args []string) error {
+	// Check if the specified user has a mapping provided. If yes,
+	// then get the hostUid, hostGid, hostSuppGids corresponding to it.
+	uid, gid, suppGroups, err := user.GetUserGroupSupplementary(container.User, syscall.Getuid(), syscall.Getgid())
+	if err != nil {
+		return fmt.Errorf("get supplementary groups %s", err)
+	}
+
+	userNsUid := uint32(uid)
+	userNsGid := uint32(gid)
+	userNsSuppGids := make([]uint32, len(suppGroups))
+	for i, sg := range suppGroups {
+		userNsSuppGids[i] = uint32(sg)
+	}
+
+	hostUid, found := hostIdFromMapping(userNsUid, container.UidMappings)
+	if !found {
+		hostUid = OverFlowUid
+	}
+
+	hostGid, found := hostIdFromMapping(userNsGid, container.GidMappings)
+	if !found {
+		hostGid = OverFlowGid
+	}
+
+	unmappedSuppGroupAdded := false
+	var hostSuppGids []int
+	for _, sgid := range userNsSuppGids {
+		gid, found := hostIdFromMapping(sgid, container.GidMappings)
+		if !found && !unmappedSuppGroupAdded {
+			hostSuppGids = append(hostSuppGids, int(OverFlowGid))
+			unmappedSuppGroupAdded = true
+		} else {
+			hostSuppGids = append(hostSuppGids, int(gid))
+		}
+	}
+
+	pdeathSignal, err := system.GetParentDeathSignal()
+	if err != nil {
+		return fmt.Errorf("get parent death signal %s", err)
+	}
+
+	// Retain capabilities on clone.
+	if err := system.Prctl(syscall.PR_SET_SECUREBITS, uintptr(C.SECBIT_KEEP_CAPS|C.SECBIT_NO_SETUID_FIXUP), 0, 0, 0); err != nil {
+		return fmt.Errorf("prctl %s", err)
+	}
+
+	// Switch to the calculated host uid.
+	if err := system.Setuid(int(hostUid)); err != nil {
+		return fmt.Errorf("setuid %s", err)
+	}
+
+	// Switch to the calculated host gid.
+	if err := system.Setgid(int(hostGid)); err != nil {
+		return fmt.Errorf("setgid %s", err)
+	}
+
+	// Set the calculated supplementary groups.
+	if err := system.Setgroups(hostSuppGids); err != nil {
+		return fmt.Errorf("setgroups %s", err)
+	}
+
+	// Changing user/group clears the parent death
+	// signal, so we restore it here.
+	if err := RestoreParentDeathSignal(pdeathSignal); err != nil {
+		return fmt.Errorf("restore parent death signal %s", err)
+	}
+
+	// Switch into a new user namespace.
+	rFd, wFd, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+
+	// Lookup the path to the command.
+	cmd, err := exec.LookPath(args[0])
+	if err != nil {
+		return err
+	}
+
+	// Prepare arguments for the raw syscalls.
+	var (
+		r1         uintptr
+		err1       syscall.Errno
+		dir        *byte
+		rawReadFd  uintptr
+		rawWriteFd uintptr
+		lzero      uintptr
+	)
+
+	argv0p, err := syscall.BytePtrFromString(cmd)
+	if err != nil {
+		return err
+	}
+
+	argvp, err := syscall.SlicePtrFromStrings(args[0:])
+	if err != nil {
+		return err
+	}
+
+	envvp, err := syscall.SlicePtrFromStrings(container.Env)
+	if err != nil {
+		return err
+	}
+
+	if container.WorkingDir != "" {
+		dir, err = syscall.BytePtrFromString(container.WorkingDir)
+		if err != nil {
+			return err
+		}
+	}
+
+	rawReadFd = rFd.Fd()
+	rawWriteFd = wFd.Fd()
+
+	if err := utils.CloseExecFrom(3); err != nil {
+		return fmt.Errorf("close open file descriptors %s", err)
+	}
+
+	syscall.ForkLock.Lock()
+	r1, _, err1 = syscall.RawSyscall6(syscall.SYS_CLONE, uintptr(syscall.CLONE_NEWUSER|syscall.SIGCHLD), 0, 0, 0, 0, 0)
+	if err1 != 0 {
+		return fmt.Errorf("userns clone: %s", err)
+	}
+
+	if r1 != 0 {
+		// In parent.
+		syscall.ForkLock.Unlock()
+		proc, err := os.FindProcess(int(r1))
+		if err != nil {
+			return err
+		}
+
+		if err = writeUserMappings(int(r1), container.UidMappings, container.GidMappings); err != nil {
+			proc.Kill()
+			return fmt.Errorf("Failed to write mappings: %s", err)
+		}
+
+		rFd.Close()
+		wFd.Close()
+
+		state, err := proc.Wait()
+		if err != nil {
+			proc.Kill()
+			return fmt.Errorf("wait: %s", err)
+		}
+		os.Exit(state.Sys().(syscall.WaitStatus).ExitStatus())
+	}
+
+	// In child.
+	// Wait for parent to write the mappings.
+	syscall.RawSyscall(syscall.SYS_CLOSE, rawWriteFd, 0, 0)
+	_, _, e1 := syscall.RawSyscall(syscall.SYS_READ, rawReadFd, uintptr(unsafe.Pointer(&lzero)), uintptr(1))
+	if e1 != 0 {
+		return e1
+	}
+
+	if dir != nil {
+		_, _, err1 = syscall.RawSyscall(syscall.SYS_CHDIR, uintptr(unsafe.Pointer(dir)), 0, 0)
+		if err1 != 0 {
+			return err1
+		}
+	}
+
+	_, _, err1 = syscall.RawSyscall(syscall.SYS_EXECVE,
+		uintptr(unsafe.Pointer(argv0p)),
+		uintptr(unsafe.Pointer(&argvp[0])),
+		uintptr(unsafe.Pointer(&envvp[0])))
+
+	return nil
+}
+
+// Write UID/GID mappings for a process.
+func writeUserMappings(pid int, uidMappings, gidMappings []libcontainer.IdMap) error {
+	if len(uidMappings) > 5 || len(gidMappings) > 5 {
+		return fmt.Errorf("Only 5 uid/gid mappings are supported by the kernel")
+	}
+
+	uidMapStr := make([]string, len(uidMappings))
+	for i, um := range uidMappings {
+		uidMapStr[i] = fmt.Sprintf("%v %v %v", um.ContainerId, um.HostId, um.Size)
+	}
+
+	gidMapStr := make([]string, len(gidMappings))
+	for i, gm := range gidMappings {
+		gidMapStr[i] = fmt.Sprintf("%v %v %v", gm.ContainerId, gm.HostId, gm.Size)
+	}
+
+	uidMap := []byte(strings.Join(uidMapStr, "\n"))
+	gidMap := []byte(strings.Join(gidMapStr, "\n"))
+
+	uidMappingsFile := fmt.Sprintf("/proc/%v/uid_map", pid)
+	gidMappingsFile := fmt.Sprintf("/proc/%v/gid_map", pid)
+
+	if err := ioutil.WriteFile(uidMappingsFile, uidMap, 0644); err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(gidMappingsFile, gidMap, 0644); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // RestoreParentDeathSignal sets the parent death signal to old.

--- a/namespaces/types_linux.go
+++ b/namespaces/types_linux.go
@@ -1,8 +1,43 @@
 package namespaces
 
 import (
+	"io/ioutil"
+	"log"
+	"strconv"
+	"strings"
 	"syscall"
 )
+
+var (
+	OverFlowUid uint32
+	OverFlowGid uint32
+)
+
+func setupOverFlowUidGid() error {
+	var err error
+	overflowuidstr, err := ioutil.ReadFile("/proc/sys/kernel/overflowuid")
+	if err != nil {
+		return err
+	}
+	overflowgidstr, err := ioutil.ReadFile("/proc/sys/kernel/overflowgid")
+	if err != nil {
+		return err
+	}
+
+	overFlowUid64, err := strconv.ParseUint(strings.TrimSpace(string(overflowuidstr)), 10, 32)
+	if err != nil {
+		return err
+	}
+	OverFlowUid = uint32(overFlowUid64)
+
+	overFlowGid64, err := strconv.ParseUint(strings.TrimSpace(string(overflowgidstr)), 10, 32)
+	if err != nil {
+		return err
+	}
+	OverFlowGid = uint32(overFlowGid64)
+
+	return nil
+}
 
 func init() {
 	namespaceList = Namespaces{
@@ -12,5 +47,9 @@ func init() {
 		{Key: "NEWUSER", Value: syscall.CLONE_NEWUSER, File: "user"},
 		{Key: "NEWPID", Value: syscall.CLONE_NEWPID, File: "pid"},
 		{Key: "NEWNET", Value: syscall.CLONE_NEWNET, File: "net"},
+	}
+
+	if err := setupOverFlowUidGid(); err != nil {
+		log.Fatalf("Failed to read overflowuid/overflowgid: %v")
 	}
 }

--- a/sample_configs/user_ns.json
+++ b/sample_configs/user_ns.json
@@ -1,0 +1,220 @@
+{
+  "capabilities": [
+    "CHOWN",
+    "DAC_OVERRIDE",
+    "FOWNER",
+    "MKNOD",
+    "NET_RAW",
+    "SETGID",
+    "SETUID",
+    "SETFCAP",
+    "SETPCAP",
+    "NET_BIND_SERVICE",
+    "SYS_CHROOT",
+    "KILL"
+  ],
+  "cgroups": {
+    "allowed_devices": [
+      {
+        "cgroup_permissions": "m",
+        "major_number": -1,
+        "minor_number": -1,
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "m",
+        "major_number": -1,
+        "minor_number": -1,
+        "type": 98
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "major_number": 5,
+        "minor_number": 1,
+        "path": "/dev/console",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "major_number": 4,
+        "path": "/dev/tty0",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "major_number": 4,
+        "minor_number": 1,
+        "path": "/dev/tty1",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "major_number": 136,
+        "minor_number": -1,
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "major_number": 5,
+        "minor_number": 2,
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "major_number": 10,
+        "minor_number": 200,
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 1,
+        "minor_number": 3,
+        "path": "/dev/null",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 1,
+        "minor_number": 5,
+        "path": "/dev/zero",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 1,
+        "minor_number": 7,
+        "path": "/dev/full",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 5,
+        "path": "/dev/tty",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 1,
+        "minor_number": 9,
+        "path": "/dev/urandom",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 1,
+        "minor_number": 8,
+        "path": "/dev/random",
+        "type": 99
+      }
+    ],
+    "name": "docker-koye",
+    "parent": "docker"
+  },
+  "restrict_sys": true,
+  "mount_config": {
+    "device_nodes": [
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 1,
+        "minor_number": 3,
+        "path": "/dev/null",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 1,
+        "minor_number": 5,
+        "path": "/dev/zero",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 1,
+        "minor_number": 7,
+        "path": "/dev/full",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 5,
+        "path": "/dev/tty",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 1,
+        "minor_number": 9,
+        "path": "/dev/urandom",
+        "type": 99
+      },
+      {
+        "cgroup_permissions": "rwm",
+        "file_mode": 438,
+        "major_number": 1,
+        "minor_number": 8,
+        "path": "/dev/random",
+        "type": 99
+      }
+    ]
+  },
+  "environment": [
+    "HOME=/",
+    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "HOSTNAME=koye",
+    "TERM=xterm"
+  ],
+  "hostname": "koye",
+  "namespaces": {
+    "NEWIPC": true,
+    "NEWNET": true,
+    "NEWNS": true,
+    "NEWPID": true,
+    "NEWUTS": true,
+    "NEWUSER": true
+  },
+  "networks": [
+    {
+      "address": "127.0.0.1/0",
+      "gateway": "localhost",
+      "mtu": 1500,
+      "type": "loopback"
+    }
+  ],
+  "tty": true,
+  "user": "root",
+  "uid_mappings": [
+    {
+      "container_id": 0,
+      "host_id": 1013,
+      "size": 1
+    },
+    {
+      "container_id": 1,
+      "host_id": 1,
+      "size": 1012
+    }
+  ],
+  "gid_mappings": [
+    {
+      "container_id": 0,
+      "host_id": 1013,
+      "size": 1
+    },
+    {
+      "container_id": 1,
+      "host_id": 1,
+      "size": 1012
+    }
+  ]
+}


### PR DESCRIPTION
Here we use container.User to get the uid/gid/suppGids in the container and then look them up in the mappings to get the corresponding uid/gid/suppGids on the host. We switch to those ids in the parent before the call to clone into new userns.

If no mapping is found, then we use the overflowuid/overflowgid.

For sample integration with docker see -- https://github.com/mrunalp/docker/compare/dev/userns_alt?expand=1
Docker-DCO-1.1-Signed-off-by: Mrunal Patel mrunalp@gmail.com (github: mrunalp)
