### PR TITLE
fix the order of setns()

### DIFF
--- a/namespaces/nsenter.go
+++ b/namespaces/nsenter.go
@@ -3,7 +3,6 @@
 package namespaces
 
 /*
-#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/limits.h>
@@ -12,7 +11,6 @@ package namespaces
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <getopt.h>


### PR DESCRIPTION
You cannot attach to namespaces in random order.
If you enter the mnt namespace before pid your procfs will go nuts.
Note that readdir() doesn't guarantee any ordering.
