### PR TITLE
Separate nsinit main from implementation

### DIFF
--- a/nsinit/cli.go
+++ b/nsinit/cli.go
@@ -1,4 +1,4 @@
-package main
+package nsinit
 
 import (
 	"log"
@@ -19,7 +19,7 @@ func preload(context *cli.Context) error {
 	return nil
 }
 
-func main() {
+func NsInit() {
 	app := cli.NewApp()
 	app.Name = "nsinit"
 	app.Version = "0.1"

--- a/nsinit/config.go
+++ b/nsinit/config.go
@@ -1,4 +1,4 @@
-package main
+package nsinit
 
 import (
 	"encoding/json"

--- a/nsinit/exec.go
+++ b/nsinit/exec.go
@@ -1,4 +1,4 @@
-package main
+package nsinit
 
 import (
 	"fmt"

--- a/nsinit/init.go
+++ b/nsinit/init.go
@@ -1,4 +1,4 @@
-package main
+package nsinit
 
 import (
 	"log"

--- a/nsinit/main/nsinit.go
+++ b/nsinit/main/nsinit.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/docker/libcontainer/nsinit"
+
+func main() {
+	nsinit.NsInit()
+}

--- a/nsinit/nsenter.go
+++ b/nsinit/nsenter.go
@@ -1,4 +1,4 @@
-package main
+package nsinit
 
 import (
 	"log"

--- a/nsinit/pause.go
+++ b/nsinit/pause.go
@@ -1,4 +1,4 @@
-package main
+package nsinit
 
 import (
 	"log"

--- a/nsinit/stats.go
+++ b/nsinit/stats.go
@@ -1,4 +1,4 @@
-package main
+package nsinit
 
 import (
 	"encoding/json"

--- a/nsinit/utils.go
+++ b/nsinit/utils.go
@@ -1,4 +1,4 @@
-package main
+package nsinit
 
 import (
 	"encoding/json"


### PR DESCRIPTION
This is done in order to package nsinit as part of docker binary.
