### PR TITLE
enable hairpin mode on virtual interface bridge port

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -95,3 +95,11 @@ func SetMtu(name string, mtu int) error {
 	}
 	return netlink.NetworkSetMTU(iface, mtu)
 }
+
+func SetHairpinMode(name string, enabled bool) error {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return err
+	}
+	return netlink.SetHairpinMode(iface, enabled)
+}

--- a/network/veth.go
+++ b/network/veth.go
@@ -39,6 +39,9 @@ func (v *Veth) Create(n *Network, nspid int, networkState *NetworkState) error {
 	if err := SetMtu(name1, n.Mtu); err != nil {
 		return err
 	}
+	if err := SetHairpinMode(name1, true); err != nil {
+		return err
+	}
 	if err := InterfaceUp(name1); err != nil {
 		return err
 	}


### PR DESCRIPTION
This is to support being able to DNAT/MASQ traffic from a container back into itself (dotcloud/docker#4442)

See subsequent pull request on docker project for details.
