### PR TITLE
Add a cleanup method to cgroup fs. This will help in building a

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -52,6 +52,14 @@ func Apply(c *cgroups.Cgroup, pid int) (cgroups.ActiveCgroup, error) {
 	return d, nil
 }
 
+func Cleanup(c *cgroups.Cgroup) error {
+	d, err := getCgroupData(c, 0)
+	if err != nil {
+		return fmt.Errorf("Could not get Cgroup data %s", err)
+	}
+	return d.Cleanup()
+}
+
 func GetStats(c *cgroups.Cgroup) (*cgroups.Stats, error) {
 	stats := cgroups.NewStats()
 


### PR DESCRIPTION
Add a cleanup method to cgroup fs implementation. This will help in building a standalone cgroup test util. systemd does auto cleanup on empty, so doesn't need an extra interface.

Docker-DCO-1.1-Signed-off-by: Rohit Jnagal jnagal@google.com (github: rjnagal)
