### PR TITLE
Use conventional factory terminology

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -1,7 +1,7 @@
 package libcontainer
 
 type Factory interface {
-	// Initializes a new container in the given path. A unique ID is generated for the container and
+	// Creates a new container in the given path. A unique ID is generated for the container and
 	// starts the initial process inside the container.
 	//
 	// Returns the new container with a running process.
@@ -12,7 +12,7 @@ type Factory interface {
 	// System error
 	//
 	// On error, any partially created container parts are cleaned up (the operation is atomic).
-	Initialize(path string, config *Config) (Container, error)
+	Create(path string, config *Config) (Container, error)
 
 	// Load takes the path for an existing container and reconstructs the container
 	// from the state.


### PR DESCRIPTION
The Initialize method is responsible for creating a new Container instance
and calling it Create makes the factory pattern more obvious. Clearly
creating a Container instance involves initialising the instance.

Docker-DCO-1.1-Signed-off-by: Glyn Normington gnormington@gopivotal.com (github: glyn)
