### PR TITLE
Remove filesystem implementation bias from API

### DIFF
--- a/container.go
+++ b/container.go
@@ -3,44 +3,86 @@ NOTE: The API is in flux and mainly not implemented. Proceed with caution until 
 */
 package libcontainer
 
-// A libcontainer container object.
+// A Memento contains private state. A Memento and associated system resources are sufficient to reconstruct a Container
+// value.
+type Memento []byte
+
+// A Memo function receives Mementos.
 //
-// Each container is thread-safe within the same process. Since a container can
-// be destroyed by a separate process, any function may return that the container
-// was not found.
+// The container identifier (see Id()) and the Memento are passed as parameters. If the Memento is nil, this indicates
+// the container has been destroyed. If the Memento is non-nil, it represents the state of the container.
+//
+// The return boolean determines whether the Memo function will be called again. The function
+// may be called again if it returns true but will not be called again if it returns false.
+//
+// A Memo function must not call the libcontainer API otherwise the behaviour is undefined.
+type Memo func(id string, memento Memento) bool
+
+// A Container value accesses, and may control, a system container, implemented with system resources.
+//
+// Containers are created using the Factory interface.
+//
+// The Container value and the system container between them constitute the entire state of the container. Multiple
+// Container values can refer to the same system container but at most one may control the system container. The Factory
+// interface describes which Container value controls the system container.
+//
+// The Container value that controls a system container is allowed to update it. Updates from other Container values
+// are undefined.
+//
+// After Destroy() all methods (except Id()) will return 'container no longer exists'.
 type Container interface {
-	// Returns the path to the container which contains the state
-	Path() string
+	// Returns a system-wide, unique, automatically generated identifier for this container.
+	Id() string
 
 	// Returns the current run state of the container.
 	//
-	// Errors: container no longer exists,
-	//         system error.
+	// Errors:
+	// Container no longer exists
+	// System error
 	RunState() (*RunState, error)
 
 	// Returns the current config of the container.
 	Config() *Config
 
-	// Start a process inside the container. Returns the PID of the new process (in the caller process's namespace) and a channel that will return the exit status of the process whenever it dies.
+	// Registers a Memo function with this Container. libcontainer calls the Memo to provide Mementos which can be used
+	// to re-create the Container (see Factory.Import).
 	//
-	// Errors: container no longer exists,
-	//         config is invalid,
-	//         container is paused,
-	//         system error.
+	// Calls the given Memo synchronously before RegisterMemo returns and, asynchronously after RegisterMemo returns,
+	// each time the Memento changes or the container is destroyed.
+	//
+	// Multiple Memo functions may be registered with a given Container. A single Memo function may be registered with
+	// multiple Containers.
+	//
+	// Errors:
+	// Container no longer exists
+	// System error
+	// TODO: replace this with a "memo" event type when events are introduced.
+	RegisterMemo(memo Memo) error
+
+	// Start a process inside the container. Returns the PID of the new process (in the caller process's namespace) and
+	// a channel that will return the exit status of the process whenever it dies.
+	//
+	// Errors:
+	// Container no longer exists
+	// Config is invalid
+	// Container is paused
+	// System error
 	Start(*ProcessConfig) (pid int, exitChan chan int, err error)
 
 	// Destroys the container after killing all running processes.
 	//
-	// Any event registrations are removed before the container is destroyed.
-	// No error is returned if the container is already destroyed.
+	// Any registered Memos are notified with a nil Memento and are not subsequently called for this container.
+	// No action is taken if the container is already destroyed.
 	//
-	// Errors: system error.
+	// Errors:
+	// System error
 	Destroy() error
 
 	// Returns the PIDs inside this container. The PIDs are in the namespace of the calling process.
 	//
-	// Errors: container no longer exists,
-	//         system error.
+	// Errors:
+	// Container no longer exists
+	// System error
 	//
 	// Some of the returned PIDs may no longer refer to processes in the Container, unless
 	// the Container state is PAUSED in which case every PID in the slice is valid.
@@ -48,8 +90,9 @@ type Container interface {
 
 	// Returns statistics for the container.
 	//
-	// Errors: container no longer exists,
-	//         system error.
+	// Errors:
+	// Container no longer exists
+	// System error
 	Stats() (*ContainerStats, error)
 
 	// If the Container state is RUNNING or PAUSING, sets the Container state to PAUSING and pauses
@@ -57,15 +100,17 @@ type Container interface {
 	// state is changed to PAUSED.
 	// If the Container state is PAUSED, do nothing.
 	//
-	// Errors: container no longer exists,
-	//         system error.
+	// Errors:
+	// Container no longer exists
+	// System error
 	Pause() error
 
 	// If the Container state is PAUSED, resumes the execution of any user processes in the
 	// Container before setting the Container state to RUNNING.
 	// If the Container state is RUNNING, do nothing.
 	//
-	// Errors: container no longer exists,
-	//         system error.
+	// Errors:
+	// Container no longer exists
+	// System error
 	Resume() error
 }

--- a/factory.go
+++ b/factory.go
@@ -1,25 +1,37 @@
 package libcontainer
 
+// A Factory generates new (or recovers old) Containers.
 type Factory interface {
-	// Creates a new container in the given path. A unique ID is generated for the container and
-	// starts the initial process inside the container.
+	// Creates a new container with the given configuration.
+	// Returns the new container.
 	//
-	// Returns the new container with a running process.
+	// The new Container value controls the system container.
 	//
 	// Errors:
-	// Path already exists
-	// Config or initialConfig is invalid
+	// Config is invalid
 	// System error
 	//
 	// On error, any partially created container parts are cleaned up (the operation is atomic).
-	Create(path string, config *Config) (Container, error)
+	Create(config *Config) (Container, error)
 
-	// Load takes the path for an existing container and reconstructs the container
-	// from the state.
+	// Recreates a Container value from the given Memento (which was previously passed to a Memo function).
+	// Returns the recreated Container.
+	//
+	// The nil Memento is invalid.
+	//
+	// If no Container value is in control, the recreated Container value now controls the system container.
+	//
+	// Import has two intended uses. It may be used to recover a Container if the original value is lost, for example if
+	// the creating process terminates. In this case, the recovered Container is fully functional except that it has no
+	// Memo functions registered.
+	//
+	// Import may also be used to access an existing system container. In this case, the recovered Container value should
+	// is not in control and should only be used to read information, for example to gather statistics. There is no point
+	// in registering a Memo function with this Container.
 	//
 	// Errors:
-	// Path does not exist
-	// Container is stopped
+	// Container no longer exists
+	// Invalid memento
 	// System error
-	Load(path string) (Container, error)
+	Import(memento Memento) (Container, error)
 }


### PR DESCRIPTION
Bring the API into line with the IRC discussion, July 17.

There seemed to be a consensus that the API should be dealing with individual containers and collecting together containers and allowing access from other processes should be the responsibility of the caller.
- Remove `Path()` and add `Id()` in `Container` interface. Update description.
- Remove `Load()` and modify `Create()` in `Factory` interface to remove references to path.
  Update description of `Create()`.

The `libcontainer` API deals only with individual `Container` instances, and does not
provide a 'reaccess' method. `Id()` is exposed for diagnostic information.

Docker-DCO-1.1-Signed-off-by: Steven Powell spowell@gopivotal.com (github: Zteve)
