### PR TITLE
Use restriction paths with rootfs

### DIFF
--- a/namespaces/init.go
+++ b/namespaces/init.go
@@ -98,7 +98,13 @@ func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, syn
 
 	// TODO: (crosbymichael) make this configurable at the Config level
 	if container.RestrictSys {
-		if err := restrict.Restrict("proc/sys", "proc/sysrq-trigger", "proc/irq", "proc/bus", "sys"); err != nil {
+		if err := restrict.Restrict(rootfs, []string{
+			"proc/sys",
+			"proc/sysrq-trigger",
+			"proc/irq",
+			"proc/bus",
+			"sys",
+		}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
There is an issues where this works as expected in normal containers and
the root was not needed.  However, if you drop the NET namespace from
the container the mount of sysfs on the host machines is mounted as ro
instead of only affecting the container.

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@docker.com (github: crosbymichael)
