### PR TITLE
Add busybox rootfs so we can run containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,19 @@ FROM crosbymichael/golang
 RUN apt-get update && apt-get install -y gcc
 RUN go get code.google.com/p/go.tools/cmd/cover
 
-ADD . /go/src/github.com/docker/libcontainer
+# setup a playground for us to spawn containers in
+RUN mkdir /busybox && \
+    curl -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.02/rootfs.tar' | tar -xC /busybox && \
+    echo "daemon:x:1:1:daemon:/sbin:/sbin/nologin" >> /busybox/etc/passwd
+
+RUN curl -sSL https://raw.githubusercontent.com/dotcloud/docker/master/hack/dind -o /dind && \
+    chmod +x /dind
+
+COPY . /go/src/github.com/docker/libcontainer
 WORKDIR /go/src/github.com/docker/libcontainer
+RUN cp sample_configs/minimal.json /busybox/container.json
+
 RUN go get -d ./... && go install ./...
 
+ENTRYPOINT ["/dind"]
 CMD ["go", "test", "-cover", "./..."]

--- a/Makefile
+++ b/Makefile
@@ -3,5 +3,8 @@ all:
 	docker build -t docker/libcontainer .
 
 test:
-	# we need NET_ADMIN for the netlink tests
-	docker run --rm --cap-add NET_ADMIN docker/libcontainer
+	# we need NET_ADMIN for the netlink tests and SYS_ADMIN for mounting
+	docker run --rm --cap-add NET_ADMIN --cap-add SYS_ADMIN docker/libcontainer
+
+sh:
+	docker run -ti -w /busybox --rm --cap-add NET_ADMIN --cap-add SYS_ADMIN docker/libcontainer nsinit exec sh


### PR DESCRIPTION
`make sh` will spawn a new container using the minimal.json file inside
busybox and you don't even know what is going on.

Docker-DCO-1.1-Signed-off-by: Michael Crosby michael@docker.com (github: crosbymichael)
