### PR TITLE
Add a couple tweaks to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ RUN go get code.google.com/p/go.tools/cmd/cover
 
 # setup a playground for us to spawn containers in
 RUN mkdir /busybox && \
-    curl -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.02/rootfs.tar' | tar -xC /busybox && \
-    echo "daemon:x:1:1:daemon:/sbin:/sbin/nologin" >> /busybox/etc/passwd
+    curl -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.02/rootfs.tar' | tar -xC /busybox
 
 RUN curl -sSL https://raw.githubusercontent.com/dotcloud/docker/master/hack/dind -o /dind && \
     chmod +x /dind
@@ -15,7 +14,8 @@ COPY . /go/src/github.com/docker/libcontainer
 WORKDIR /go/src/github.com/docker/libcontainer
 RUN cp sample_configs/minimal.json /busybox/container.json
 
-RUN go get -d ./... && go install ./...
+RUN go get -d -v ./...
+RUN go install -v ./...
 
 ENTRYPOINT ["/dind"]
 CMD ["go", "test", "-cover", "./..."]


### PR DESCRIPTION
- we don't need to add a "daemon" user to busybox; it already has one :)
- if we split out the "go get" from the "go install", we can have nice clean output on "docker build" of which dependencies we're pulling in and all the packages that get built :)

``` console
$ make
...
Step 8 : RUN go get -d -v ./...
 ---> Running in fab0bc7bdd49
github.com/coreos/go-systemd (download)
github.com/godbus/dbus (download)
github.com/dotcloud/docker (download)
github.com/codegangsta/cli (download)
github.com/syndtr/gocapability (download)
 ---> 96c804401c54
Removing intermediate container fab0bc7bdd49
Step 9 : RUN go install -v ./...
 ---> Running in 0276cbd25f28
github.com/docker/libcontainer/devices
github.com/dotcloud/docker/pkg/mount
github.com/docker/libcontainer/system
github.com/godbus/dbus
github.com/coreos/go-systemd/activation
github.com/docker/libcontainer/label
github.com/dotcloud/docker/pkg/symlink
github.com/docker/libcontainer/netlink
github.com/docker/libcontainer/console
github.com/dotcloud/docker/pkg/systemd
github.com/docker/libcontainer/utils
github.com/docker/libcontainer/apparmor
github.com/codegangsta/cli
github.com/docker/libcontainer/mount/nodes
github.com/docker/libcontainer/mount
github.com/syndtr/gocapability/capability
github.com/docker/libcontainer/security/restrict
github.com/dotcloud/docker/pkg/user
github.com/docker/libcontainer/security/capabilities
github.com/dotcloud/docker/pkg/term
github.com/docker/libcontainer/cgroups
github.com/coreos/go-systemd/dbus
github.com/docker/libcontainer/cgroups/fs
github.com/docker/libcontainer/network
github.com/docker/libcontainer/selinux
github.com/docker/libcontainer/syncpipe
github.com/docker/libcontainer/cgroups/systemd
github.com/docker/libcontainer
github.com/docker/libcontainer/cgroups/cgutil
github.com/docker/libcontainer/namespaces
github.com/docker/libcontainer/nsinit
github.com/docker/libcontainer/nsinit/nsinit
 ---> 9a099ae437f8
...
```
