### PR TITLE
in order to fix the exit status handling on docker, we need to not repor...

### DIFF
--- a/namespaces/init.go
+++ b/namespaces/init.go
@@ -5,6 +5,7 @@ package namespaces
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
 	"strings"
 	"syscall"
@@ -30,7 +31,8 @@ import (
 // and other options required for the new container.
 func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, syncPipe *syncpipe.SyncPipe, args []string) (err error) {
 	defer func() {
-		if err != nil {
+		// ErrNotFound is a system error and should not be returned to the parent
+		if err != nil && err != exec.ErrNotFound {
 			syncPipe.ReportChildError(err)
 		}
 	}()

--- a/system/linux.go
+++ b/system/linux.go
@@ -11,7 +11,7 @@ import (
 func Execv(cmd string, args []string, env []string) error {
 	name, err := exec.LookPath(cmd)
 	if err != nil {
-		return err
+		return exec.ErrNotFound
 	}
 
 	return syscall.Exec(name, args, env)


### PR DESCRIPTION
...t exec.ErrNotFound to the parent