### PR TITLE
Implement system.GetClockTicks for all platforms

### DIFF
--- a/system/sysconfig.go
+++ b/system/sysconfig.go
@@ -1,4 +1,4 @@
-// +build linux,cgo
+// +build cgo
 
 package system
 

--- a/system/sysconfig_notcgo.go
+++ b/system/sysconfig_notcgo.go
@@ -1,4 +1,4 @@
-// +build linux,!cgo
+// +build !cgo
 
 package system
 


### PR DESCRIPTION
Both linux and darwin support the sysconf call used to get clock ticks; presumably all cgo enabled platforms will as well.

This PR removes linux build flags from `sysconfig.go` and `sysconfig_notcgo.go`, which restores the ability for non-linux platforms (specifically, darwin) to include "github.com/docker/libcontainer" again.
