### PR TITLE
DefaultCreateCommand supports command w/ flags

### DIFF
--- a/namespaces/exec.go
+++ b/namespaces/exec.go
@@ -133,7 +133,7 @@ func DefaultCreateCommand(container *libcontainer.Config, console, rootfs, dataP
 	   }
 	*/
 
-	command := exec.Command(init, append([]string{"init"}, args...)...)
+	command := exec.Command(init, append([]string{"init", "--"}, args...)...)
 	// make sure the process is executed inside the context of the rootfs
 	command.Dir = rootfs
 	command.Env = append(os.Environ(), env...)


### PR DESCRIPTION
namespaces.DefaultCreateCommand prepends the user-supplied command to
execute with "--", so that "nsinit init" does not attempt to interpret
it.

Before:

```
$ sudo nsinit exec -- ls -d
Incorrect Usage.

NAME:
   init - runs the init process inside the namespace

USAGE:
   command init [arguments...]

DESCRIPTION:


2014/07/31 16:57:55 flag provided but not defined: -d
2014/07/31 16:57:55 failed to exec: read parent syncpipe: connection reset by peer
```

After:

```
$ sudo nsinit exec -- ls -d
.
```
