### PR TITLE
Fixes logic for calculating percentage

### DIFF
--- a/cgroups/fs/cpuacct.go
+++ b/cgroups/fs/cpuacct.go
@@ -54,7 +54,7 @@ func (s *CpuacctGroup) GetStats(path string, stats *cgroups.Stats) error {
 		return err
 	}
 	// sample for 100ms
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(1000 * time.Millisecond)
 	if kernelModeUsage, userModeUsage, err = getCpuUsage(path); err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func (s *CpuacctGroup) GetStats(path string, stats *cgroups.Stats) error {
 		deltaUsage  = lastUsage - startUsage
 	)
 	if deltaSystem > 0.0 {
-		percentage = uint64(((float64(deltaProc) / float64(deltaSystem)) * float64(clockTicks)) * float64(cpuCount))
+		percentage = uint64((float64(deltaProc) / float64(deltaSystem)) * float64(clockTicks*cpuCount))
 	}
 	// NOTE: a percentage over 100% is valid for POSIX because that means the
 	// processes is using multiple cores


### PR DESCRIPTION
Fixes logic for calculating percentage for cgroups.Stats.CpuStats.CpuUsage.PercentUsage

Previous logic divided a uint64 by a uint64 losing precision before multiplying by clock ticks and cpus
This fix maintains precision before converting back to uint64

Docker-DCO-1.1-Signed-off-by: Nicholas Weaver lynxbat@gmail.com (github: lynxbat)
