### PR TITLE
Adds per cpu ratio stat to cgroups cpu stats

### DIFF
--- a/cgroups/stats.go
+++ b/cgroups/stats.go
@@ -10,8 +10,10 @@ type ThrottlingData struct {
 }
 
 type CpuUsage struct {
-	// percentage of available CPUs currently being used.
+	// percentage of available CPUs currently being used (0 - ~100)
 	PercentUsage uint64 `json:"percent_usage,omitempty"`
+	// Ratio of load across CPUs (adds up to ~100)
+	RatioPercpu []float64 `json:"per_cpu_percent_usage,omitempty`
 	// nanoseconds of cpu time consumed over the last 100 ms.
 	CurrentUsage uint64 `json:"current_usage,omitempty"`
 	// total nanoseconds of cpu time consumed


### PR DESCRIPTION
cgroups.Stats.CpuStats.CpuUsage.RatioPercpu

Adds a ratio metric for the distribution of load across the cores.
This works well with the percentage metric to show if containers
are bottlenecking on accessable cpus.

Example of ratio on a 2 cpu system

```
[0.65, 0.35]
```

Docker-DCO-1.1-Signed-off-by: Nicholas Weaver lynxbat@gmail.com (github: lynxbat)
