### PR TITLE
Using namespace fds instead of paths and nspids

### DIFF
--- a/namespaces/exec.go
+++ b/namespaces/exec.go
@@ -72,7 +72,7 @@ func Exec(container *libcontainer.Config, stdin io.Reader, stdout, stderr io.Wri
 	}
 
 	var networkState network.NetworkState
-	if err := InitializeNetworking(container, command.Process.Pid, syncPipe, &networkState); err != nil {
+	if err := InitializeNetworking(container, syncPipe, &networkState); err != nil {
 		command.Process.Kill()
 		command.Wait()
 		return -1, err
@@ -173,13 +173,13 @@ func SetupCgroups(container *libcontainer.Config, nspid int) (cgroups.ActiveCgro
 
 // InitializeNetworking creates the container's network stack outside of the namespace and moves
 // interfaces into the container's net namespaces if necessary
-func InitializeNetworking(container *libcontainer.Config, nspid int, pipe *syncpipe.SyncPipe, networkState *network.NetworkState) error {
+func InitializeNetworking(container *libcontainer.Config, pipe *syncpipe.SyncPipe, networkState *network.NetworkState) error {
 	for _, config := range container.Networks {
 		strategy, err := network.GetStrategy(config.Type)
 		if err != nil {
 			return err
 		}
-		if err := strategy.Create((*network.Network)(config), nspid, networkState); err != nil {
+		if err := strategy.Create((*network.Network)(config), networkState); err != nil {
 			return err
 		}
 	}

--- a/network/loopback.go
+++ b/network/loopback.go
@@ -10,7 +10,7 @@ import (
 type Loopback struct {
 }
 
-func (l *Loopback) Create(n *Network, nspid int, networkState *NetworkState) error {
+func (l *Loopback) Create(n *Network, networkState *NetworkState) error {
 	return nil
 }
 

--- a/network/netns.go
+++ b/network/netns.go
@@ -4,7 +4,6 @@ package network
 
 import (
 	"fmt"
-	"os"
 	"syscall"
 
 	"github.com/docker/libcontainer/system"
@@ -14,22 +13,17 @@ import (
 type NetNS struct {
 }
 
-func (v *NetNS) Create(n *Network, nspid int, networkState *NetworkState) error {
-	networkState.NsPath = n.NsPath
+func (v *NetNS) Create(n *Network, networkState *NetworkState) error {
+	networkState.NetnsFd = n.NetnsFd
 	return nil
 }
 
 func (v *NetNS) Initialize(config *Network, networkState *NetworkState) error {
-	if networkState.NsPath == "" {
-		return fmt.Errorf("nspath does is not specified in NetworkState")
+	if networkState.NetnsFd == 0 {
+		return fmt.Errorf("netns fd is not specified in NetworkState")
 	}
 
-	f, err := os.OpenFile(networkState.NsPath, os.O_RDONLY, 0)
-	if err != nil {
-		return fmt.Errorf("failed get network namespace fd: %v", err)
-	}
-
-	if err := system.Setns(f.Fd(), syscall.CLONE_NEWNET); err != nil {
+	if err := system.Setns(uintptr(networkState.NetnsFd), syscall.CLONE_NEWNET); err != nil {
 		return fmt.Errorf("failed to setns current network namespace: %v", err)
 	}
 

--- a/network/strategy.go
+++ b/network/strategy.go
@@ -19,7 +19,7 @@ var strategies = map[string]NetworkStrategy{
 // NetworkStrategy represents a specific network configuration for
 // a container's networking stack
 type NetworkStrategy interface {
-	Create(*Network, int, *NetworkState) error
+	Create(*Network, *NetworkState) error
 	Initialize(*Network, *NetworkState) error
 }
 

--- a/network/types.go
+++ b/network/types.go
@@ -8,8 +8,8 @@ type Network struct {
 	// Type sets the networks type, commonly veth and loopback
 	Type string `json:"type,omitempty"`
 
-	// Path to network namespace
-	NsPath string `json:"ns_path,omitempty"`
+	// NetnsFd is file descriptor of network namespace
+	NetnsFd int `json:"ns_path,omitempty"`
 
 	// The bridge to use.
 	Bridge string `json:"bridge,omitempty"`
@@ -36,6 +36,6 @@ type NetworkState struct {
 	VethHost string `json:"veth_host,omitempty"`
 	// The name of the veth interface created inside the container for the child.
 	VethChild string `json:"veth_child,omitempty"`
-	// Net namespace path.
-	NsPath string `json:"ns_path,omitempty"`
+	// NetnsFd is file descriptor of network namespace
+	NetnsFd int `json:"ns_path,omitempty"`
 }

--- a/network/veth.go
+++ b/network/veth.go
@@ -16,7 +16,7 @@ type Veth struct {
 
 const defaultDevice = "eth0"
 
-func (v *Veth) Create(n *Network, nspid int, networkState *NetworkState) error {
+func (v *Veth) Create(n *Network, networkState *NetworkState) error {
 	var (
 		bridge = n.Bridge
 		prefix = n.VethPrefix
@@ -40,7 +40,7 @@ func (v *Veth) Create(n *Network, nspid int, networkState *NetworkState) error {
 	if err := InterfaceUp(name1); err != nil {
 		return err
 	}
-	if err := SetInterfaceInNamespacePid(name2, nspid); err != nil {
+	if err := SetInterfaceInNamespaceFd(name2, uintptr(n.NetnsFd)); err != nil {
 		return err
 	}
 	networkState.VethHost = name1


### PR DESCRIPTION
This change removing hardcode usage of PID namespaces and allows to pass namespaces fd to libcontainer instead.
There will be change in docker with persistent network namespaces for each container.
