### PR TITLE
Allow docker to free container labels when containers are removed.

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -39,3 +39,7 @@ func Init() {
 func ReserveLabel(label string) error {
 	return nil
 }
+
+func UnreserveLabel(label string) error {
+	return nil
+}

--- a/label/label_selinux.go
+++ b/label/label_selinux.go
@@ -128,3 +128,11 @@ func ReserveLabel(label string) error {
 	selinux.ReserveLabel(label)
 	return nil
 }
+
+// UnreserveLabel will remove the reservation of the MCS label.
+// This will allow InitLabels to use the MCS label in a newly created
+// containers
+func UnreserveLabel(label string) error {
+	selinux.FreeLxcContexts(label)
+	return nil
+}


### PR DESCRIPTION
Currently we do not remove reservations on MCS labels when a container
is removed.  Not a big problem, since on reboot it would be freed.
But we should be cleaning this up.  Currently we support ~500,000
labels.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
