### PR TITLE
Refactoring of network package

### DIFF
--- a/namespaces/types.go
+++ b/namespaces/types.go
@@ -15,9 +15,9 @@ type (
 // into the names of the files located in /proc/<pid>/ns/* for
 // each namespace
 var (
-	namespaceList      = Namespaces{}
-	ErrUnkownNamespace = errors.New("Unknown namespace")
-	ErrUnsupported     = errors.New("Unsupported method")
+	namespaceList       = Namespaces{}
+	ErrUnknownNamespace = errors.New("Unknown namespace")
+	ErrUnsupported      = errors.New("Unsupported method")
 )
 
 func (ns *Namespace) String() string {

--- a/network/loopback.go
+++ b/network/loopback.go
@@ -10,7 +10,7 @@ import (
 type Loopback struct {
 }
 
-func (l *Loopback) Create(n *Network, nspid int, networkState *NetworkState) error {
+func (l *Loopback) Create(n *Network, nspath string, networkState *NetworkState) error {
 	return nil
 }
 

--- a/network/namespace.go
+++ b/network/namespace.go
@@ -1,0 +1,20 @@
+package network
+
+import (
+	"fmt"
+	"syscall"
+
+	"github.com/docker/libcontainer/system"
+	"github.com/docker/libcontainer/utils"
+)
+
+func SetNs(path string) error {
+	nsFd, err := utils.GetFd(path)
+	if err != nil {
+		return err
+	}
+	if err := system.Setns(nsFd, syscall.CLONE_NEWNET); err != nil {
+		return fmt.Errorf("failed to setns network namespace: %v", err)
+	}
+	return nil
+}

--- a/network/network.go
+++ b/network/network.go
@@ -6,6 +6,7 @@ import (
 	"net"
 
 	"github.com/docker/libcontainer/netlink"
+	"github.com/docker/libcontainer/utils"
 )
 
 func InterfaceUp(name string) error {
@@ -50,6 +51,18 @@ func SetInterfaceInNamespaceFd(name string, fd uintptr) error {
 		return err
 	}
 	return netlink.NetworkSetNsFd(iface, int(fd))
+}
+
+func SetInterfaceInNamespacePath(name, path string) error {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return err
+	}
+	nsFd, err := utils.GetFd(path)
+	if err != nil {
+		return err
+	}
+	return netlink.NetworkSetNsFd(iface, int(nsFd))
 }
 
 func SetInterfaceMaster(name, master string) error {

--- a/network/strategy.go
+++ b/network/strategy.go
@@ -19,7 +19,7 @@ var strategies = map[string]NetworkStrategy{
 // NetworkStrategy represents a specific network configuration for
 // a container's networking stack
 type NetworkStrategy interface {
-	Create(*Network, int, *NetworkState) error
+	Create(*Network, string, *NetworkState) error
 	Initialize(*Network, *NetworkState) error
 }
 

--- a/network/veth.go
+++ b/network/veth.go
@@ -17,7 +17,7 @@ type Veth struct {
 
 const defaultDevice = "eth0"
 
-func (v *Veth) Create(n *Network, nspid int, networkState *NetworkState) error {
+func (v *Veth) Create(n *Network, nspath string, networkState *NetworkState) error {
 	var (
 		bridge     = n.Bridge
 		prefix     = n.VethPrefix
@@ -45,9 +45,11 @@ func (v *Veth) Create(n *Network, nspid int, networkState *NetworkState) error {
 	if err := InterfaceUp(name1); err != nil {
 		return err
 	}
-	if err := SetInterfaceInNamespacePid(name2, nspid); err != nil {
+
+	if err := SetInterfaceInNamespacePath(name2, nspath); err != nil {
 		return err
 	}
+	networkState.NsPath = nspath
 	networkState.VethHost = name1
 	networkState.VethChild = name2
 
@@ -58,6 +60,13 @@ func (v *Veth) Initialize(config *Network, networkState *NetworkState) error {
 	var vethChild = networkState.VethChild
 	if vethChild == "" {
 		return fmt.Errorf("vethChild is not specified")
+	}
+	if networkState.NsPath == "" {
+		return fmt.Errorf("nspath does is not specified in NetworkState")
+	}
+
+	if err := SetNs(networkState.NsPath); err != nil {
+		return err
 	}
 	if err := InterfaceDown(vethChild); err != nil {
 		return fmt.Errorf("interface down %s %s", vethChild, err)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -3,8 +3,10 @@ package utils
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"syscall"
@@ -52,4 +54,14 @@ func CloseExecFrom(minFd int) error {
 		// the cases where this might fail are basically file descriptors that have already been closed (including and especially the one that was created when ioutil.ReadDir did the "opendir" syscall)
 	}
 	return nil
+}
+
+func GetFd(path string) (uintptr, error) {
+	f, err := os.OpenFile(path, os.O_RDONLY, 0)
+	if err != nil {
+		return 0, fmt.Errorf("failed get namespace fd: %v", err)
+	}
+	fd := f.Fd()
+	f.Close()
+	return fd, nil
 }


### PR DESCRIPTION
Now network namespace always controlled by network.NsPath
Actually I'm not sure that I should do `SetNs` in `veth.Initialize`, maybe it should be controlled by `NetNs` above `Veth`, but this is not very convenient. WDYT?
