### PR TITLE
Use blkio.throttle.* stats when CFQ is not in use

### DIFF
--- a/cgroups/fs/blkio.go
+++ b/cgroups/fs/blkio.go
@@ -115,6 +115,14 @@ func getBlkioStat(path string) ([]cgroups.BlkioStatEntry, error) {
 }
 
 func (s *BlkioGroup) GetStats(path string, stats *cgroups.Stats) error {
+	// Try to read CFQ stats available on all CFQ enabled kernels first
+	if blkioStats, err := getBlkioStat(filepath.Join(path, "blkio.io_serviced_recursive")); err == nil && blkioStats != nil {
+		return getCFQStats(path, stats)
+	}
+	return getStats(path, stats) // Use generic stats as fallback
+}
+
+func getCFQStats(path string, stats *cgroups.Stats) error {
 	var blkioStats []cgroups.BlkioStatEntry
 	var err error
 
@@ -137,6 +145,23 @@ func (s *BlkioGroup) GetStats(path string, stats *cgroups.Stats) error {
 		return err
 	}
 	stats.BlkioStats.IoQueuedRecursive = blkioStats
+
+	return nil
+}
+
+func getStats(path string, stats *cgroups.Stats) error {
+	var blkioStats []cgroups.BlkioStatEntry
+	var err error
+
+	if blkioStats, err = getBlkioStat(filepath.Join(path, "blkio.throttle.io_service_bytes")); err != nil {
+		return err
+	}
+	stats.BlkioStats.IoServiceBytesRecursive = blkioStats
+
+	if blkioStats, err = getBlkioStat(filepath.Join(path, "blkio.throttle.io_serviced")); err != nil {
+		return err
+	}
+	stats.BlkioStats.IoServicedRecursive = blkioStats
 
 	return nil
 }

--- a/cgroups/fs/cpu_test.go
+++ b/cgroups/fs/cpu_test.go
@@ -24,6 +24,7 @@ func TestCpuStats(t *testing.T) {
 	})
 
 	cpu := &CpuGroup{}
+	actualStats := *cgroups.NewStats()
 	err := cpu.GetStats(helper.CgroupPath, &actualStats)
 	if err != nil {
 		t.Fatal(err)
@@ -42,6 +43,7 @@ func TestNoCpuStatFile(t *testing.T) {
 	defer helper.cleanup()
 
 	cpu := &CpuGroup{}
+	actualStats := *cgroups.NewStats()
 	err := cpu.GetStats(helper.CgroupPath, &actualStats)
 	if err != nil {
 		t.Fatal("Expected not to fail, but did")
@@ -59,6 +61,7 @@ func TestInvalidCpuStat(t *testing.T) {
 	})
 
 	cpu := &CpuGroup{}
+	actualStats := *cgroups.NewStats()
 	err := cpu.GetStats(helper.CgroupPath, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failed stat parsing.")

--- a/cgroups/fs/memory_test.go
+++ b/cgroups/fs/memory_test.go
@@ -25,6 +25,7 @@ func TestMemoryStats(t *testing.T) {
 	})
 
 	memory := &MemoryGroup{}
+	actualStats := *cgroups.NewStats()
 	err := memory.GetStats(helper.CgroupPath, &actualStats)
 	if err != nil {
 		t.Fatal(err)
@@ -42,6 +43,7 @@ func TestMemoryStatsNoStatFile(t *testing.T) {
 	})
 
 	memory := &MemoryGroup{}
+	actualStats := *cgroups.NewStats()
 	err := memory.GetStats(helper.CgroupPath, &actualStats)
 	if err != nil {
 		t.Fatal(err)
@@ -57,6 +59,7 @@ func TestMemoryStatsNoUsageFile(t *testing.T) {
 	})
 
 	memory := &MemoryGroup{}
+	actualStats := *cgroups.NewStats()
 	err := memory.GetStats(helper.CgroupPath, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")
@@ -72,6 +75,7 @@ func TestMemoryStatsNoMaxUsageFile(t *testing.T) {
 	})
 
 	memory := &MemoryGroup{}
+	actualStats := *cgroups.NewStats()
 	err := memory.GetStats(helper.CgroupPath, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")
@@ -88,6 +92,7 @@ func TestMemoryStatsBadStatFile(t *testing.T) {
 	})
 
 	memory := &MemoryGroup{}
+	actualStats := *cgroups.NewStats()
 	err := memory.GetStats(helper.CgroupPath, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")
@@ -104,6 +109,7 @@ func TestMemoryStatsBadUsageFile(t *testing.T) {
 	})
 
 	memory := &MemoryGroup{}
+	actualStats := *cgroups.NewStats()
 	err := memory.GetStats(helper.CgroupPath, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")
@@ -120,6 +126,7 @@ func TestMemoryStatsBadMaxUsageFile(t *testing.T) {
 	})
 
 	memory := &MemoryGroup{}
+	actualStats := *cgroups.NewStats()
 	err := memory.GetStats(helper.CgroupPath, &actualStats)
 	if err == nil {
 		t.Fatal("Expected failure")


### PR DESCRIPTION
This makes blkio's GetStats try to read blkio.io_serviced_recursive
first and fall back to read the stats from blkio.throttle in case it
can't. blkio.io_serviced_recursive seems to be available across all
kernels with CFQ enabled.

This closes #165

nb: I've made actualStats a local variable in the tests. This was necessary because GetStats using the throttle stats won't touch the queue stats for example (since it doesn't have those metrics), so the actualStats in that particular test won't match the expected stats.
Let me know if I should explicitly set it nil but I don't think this is necessary. 
