### PR TITLE
add add replace route, fix displaying ipv6 addresses and routes

### DIFF
--- a/netlink/netlink_linux.go
+++ b/netlink/netlink_linux.go
@@ -487,6 +487,12 @@ func AddDefaultGw(ip, device string) error {
 	return AddRoute("", "", ip, device)
 }
 
+// Replace default gateway. Identical to:
+// ip route replace default via $ip
+func ReplaceDefaultGw(ip, device string) error {
+	return ReplaceRoute("", "", ip, device)
+}
+
 // Bring up a particular network interface
 func NetworkLinkUp(iface *net.Interface) error {
 	s, err := getNetlinkSocket()

--- a/netlink/netlink_linux.go
+++ b/netlink/netlink_linux.go
@@ -368,15 +368,20 @@ done:
 
 // Add a new route table entry.
 func AddRoute(destination, source, gateway, device string) error {
-	return addRoute(destination, source, gateway, device, syscall.NLM_F_CREATE|syscall.NLM_F_EXCL|syscall.NLM_F_ACK)
+	return manageRoute(destination, source, gateway, device, syscall.RTM_NEWROUTE, syscall.NLM_F_CREATE|syscall.NLM_F_EXCL|syscall.NLM_F_ACK)
 }
 
 // Replace route table entry.
 func ReplaceRoute(destination, source, gateway, device string) error {
-	return addRoute(destination, source, gateway, device, syscall.NLM_F_CREATE|syscall.NLM_F_REPLACE|syscall.NLM_F_ACK)
+	return manageRoute(destination, source, gateway, device, syscall.RTM_NEWROUTE, syscall.NLM_F_CREATE|syscall.NLM_F_REPLACE|syscall.NLM_F_ACK)
 }
 
-func addRoute(destination, source, gateway, device string, flags int) error {
+// Delete route table entry.
+func DeleteRoute(destination, source, gateway, device string) error {
+	return manageRoute(destination, source, gateway, device, syscall.RTM_DELROUTE, syscall.NLM_F_CREATE|syscall.NLM_F_REPLACE|syscall.NLM_F_ACK)
+}
+
+func manageRoute(destination, source, gateway, device string, action int, flags int) error {
 	if destination == "" && source == "" && gateway == "" {
 		return fmt.Errorf("one of destination, source or gateway must not be blank")
 	}
@@ -387,7 +392,7 @@ func addRoute(destination, source, gateway, device string, flags int) error {
 	}
 	defer s.Close()
 
-	wb := newNetlinkRequest(syscall.RTM_NEWROUTE, flags)
+	wb := newNetlinkRequest(action, flags)
 	msg := newRtMsg()
 	currentFamily := -1
 	var rtAttrs []*RtAttr

--- a/netlink/netlink_linux_test.go
+++ b/netlink/netlink_linux_test.go
@@ -123,4 +123,87 @@ func TestCreateVethPair(t *testing.T) {
 	if _, err := net.InterfaceByName(name2); err != nil {
 		t.Fatal(err)
 	}
+
+	if err := NetworkLinkDel(name1); err != nil {
+		t.Fatal(err)
+	}
+
+}
+
+func TestAddReplaceDelRoute(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	ok := false
+	ifaceName := "lo"
+	ip := net.ParseIP("10.10.10.10")
+	ipgwadd := net.ParseIP("10.10.10.200")
+	ipgwrep := net.ParseIP("10.10.10.201")
+	mask := net.IPv4Mask(255, 255, 255, 0)
+	ipNet := &net.IPNet{IP: ip, Mask: mask}
+
+	iface, err := net.InterfaceByName(ifaceName)
+	if err != nil {
+		t.Skip("No 'lo' interface; skipping tests")
+	}
+
+	if err := NetworkLinkAddIp(iface, ip, ipNet); err != nil {
+		t.Fatal(err)
+	}
+
+	if !ipAssigned(iface, ip) {
+		t.Fatalf("Could not locate address '%s' in lo address list.", ip.String())
+	}
+
+	if err := AddRoute("10.10.10.0/24", "", ipgwadd.String(), iface.Name); err != nil {
+		t.Fatal(err)
+	}
+
+	routes, err := NetworkGetRoutes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, route := range routes {
+		if !route.Default && route.Iface.Name == iface.Name && route.IP.String() == ipgwadd.String() {
+			ok = true
+		}
+	}
+
+	if !ok {
+		t.Fatal("can't get default route to '%s'.", ipgwadd.String())
+	}
+
+	if err := ReplaceRoute("10.10.10.0/24", "", ipgwrep.String(), iface.Name); err != nil {
+		t.Fatal(err)
+	}
+
+	routes, err = NetworkGetRoutes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ok = false
+	for _, route := range routes {
+		if !route.Default && route.Iface.Name == iface.Name && route.IP.String() == ipgwrep.String() {
+			ok = true
+		}
+	}
+
+	if !ok {
+		t.Fatal("can't get default route to '%s'.", ipgwrep.String())
+	}
+
+	if err := DeleteRoute("10.10.10.0/24", "", ipgwrep.String(), iface.Name); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NetworkLinkDelIp(iface, ip, ipNet); err != nil {
+		t.Fatal(err)
+	}
+
+	if ipAssigned(iface, ip) {
+		t.Fatalf("Located address '%s' in lo address list after removal.", ip.String())
+	}
+
 }


### PR DESCRIPTION
Sometimes we need ability to replace exiting routes with new, without deleting previous.
This patch add ability to replace route. Also has minor fixes for ipv6 addresses and ipv4/ipv6 routes.
Signed-off-by: Vasiliy Tolstov <v.tolstov@selfip.ru>