### PR TITLE
syncpipe: consume from parent before closing child

### DIFF
--- a/syncpipe/sync_pipe.go
+++ b/syncpipe/sync_pipe.go
@@ -77,6 +77,10 @@ func (s *SyncPipe) ReadFromParent(v interface{}) error {
 }
 
 func (s *SyncPipe) ReportChildError(err error) {
+	// ensure that any data sent from the parent is consumed so it doesn't
+	// receive ECONNRESET when the child writes to the pipe.
+	ioutil.ReadAll(s.child)
+
 	s.child.Write([]byte(err.Error()))
 	s.CloseChild()
 }


### PR DESCRIPTION
Previously, closing the child side of the syncpipe (after fork) before reading from the parent would cause the parent to receive ECONNRESET. This meant that if `ReportChildError` was before `ReadFromParent`, the error would not be propagated to the parent.

Now `ReportChildError` will make it has already sync'd with the parent before writing the error.
