### PR TITLE
Correct Create() api call description in Factory interface.

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -1,14 +1,20 @@
 package libcontainer
 
 type Factory interface {
-	// Creates a new container in the given path. A unique ID is generated for the container and
-	// starts the initial process inside the container.
+
+	// Creates a new container with the given id and starts the initial process inside it.
+	// id must be a string containing only letters, digits and underscores and must contain
+	// between 1 and 1024 characters, inclusive.
+	//
+	// The id must not already be in use by an existing container. Containers created using
+	// a factory with the same path (and file system) must have distinct ids.
 	//
 	// Returns the new container with a running process.
 	//
 	// Errors:
-	// Path already exists
-	// Config or initialConfig is invalid
+	// id is already in use by a container
+	// id has incorrect format
+	// config is invalid
 	// System error
 	//
 	// On error, any partially created container parts are cleaned up (the operation is atomic).


### PR DESCRIPTION
Remove erroneous reference to `path` in description and error list;
add format description for `id` string;
add "invalid format" error for `id` string;
remove initial capitals on references to parameter names;
remove reference to `initialConfig`.

I have deliberately chosen a restrictive “format description” for the id string, hoping that a better one will be forthcoming. Otherwise we can live with something like this (although whether Ω is a letter or not might vex some people).

PS: Apologies for the mess: I amended the previous commit, but of course was then inconsistent with the fork, and when I adjusted it the branch got deleted, and ...  Would be nice to know what I should have done.
