### PR TITLE
Get UID and GID for device nodes

### DIFF
--- a/devices/devices.go
+++ b/devices/devices.go
@@ -24,6 +24,8 @@ type Device struct {
 	MinorNumber       int64       `json:"minor_number,omitempty"`       // Use the wildcard constant for wildcards.
 	CgroupPermissions string      `json:"cgroup_permissions,omitempty"` // Typically just "rwm"
 	FileMode          os.FileMode `json:"file_mode,omitempty"`          // The permission bits of the file's mode
+	Uid               uint32      `json:"uid,omitempty"`
+	Gid               uint32      `json:"gid,omitempty"`
 }
 
 func GetDeviceNumberString(deviceNumber int64) string {
@@ -75,6 +77,8 @@ func GetDevice(path, cgroupPermissions string) (*Device, error) {
 		MinorNumber:       Minor(devNumber),
 		CgroupPermissions: cgroupPermissions,
 		FileMode:          fileModePermissionBits,
+		Uid:               stat_t.Uid,
+		Gid:               stat_t.Gid,
 	}, nil
 }
 

--- a/mount/nodes/nodes.go
+++ b/mount/nodes/nodes.go
@@ -48,5 +48,10 @@ func CreateDeviceNode(rootfs string, node *devices.Device) error {
 	if err := syscall.Mknod(dest, uint32(fileMode), devices.Mkdev(node.MajorNumber, node.MinorNumber)); err != nil && !os.IsExist(err) {
 		return fmt.Errorf("mknod %s %s", node.Path, err)
 	}
+
+	if err := syscall.Chown(dest, int(node.Uid), int(node.Gid)); err != nil {
+		return fmt.Errorf("chown %s to %d:%d", node.Path, node.Uid, node.Gid)
+	}
+
 	return nil
 }


### PR DESCRIPTION
Right now if users add devices to their container's via docker the uid and gid are always set to 0 and the device ownership set on their host systems are not honored.  This allows us to get the device ownership from the host devices and set the correct ownership when we add the device in the container. 

Signed-off-by: Michael Crosby crosbymichael@gmail.com
