### PR TITLE
Allow mounts to be supplied with the MS_SLAVE option.

### DIFF
--- a/mount/mount.go
+++ b/mount/mount.go
@@ -17,6 +17,7 @@ type Mount struct {
 	Writable    bool   `json:"writable,omitempty"`
 	Relabel     string `json:"relabel,omitempty"` // Relabel source if set, "z" indicates shared, "Z" indicates unshared
 	Private     bool   `json:"private,omitempty"`
+	Slave       bool   `json:"slave,omitempty"`
 }
 
 func (m *Mount) Mount(rootfs, mountLabel string) error {
@@ -38,6 +39,10 @@ func (m *Mount) bindMount(rootfs, mountLabel string) error {
 
 	if !m.Writable {
 		flags = flags | syscall.MS_RDONLY
+	}
+
+	if m.Slave {
+		flags = flags | syscall.MS_SLAVE
 	}
 
 	stat, err := os.Stat(m.Source)


### PR DESCRIPTION
This allows bi-directional read/write of a bind mounted file. I need this for /etc/hosts rewriting in docker.
