### PR TITLE
Devices error injection

### DIFF
--- a/devices/devices.go
+++ b/devices/devices.go
@@ -19,7 +19,8 @@ var (
 
 // Testing dependencies
 var (
-	osLstat = os.Lstat
+	osLstat       = os.Lstat
+	ioutilReadDir = ioutil.ReadDir
 )
 
 type Device struct {
@@ -92,7 +93,7 @@ func GetHostDeviceNodes() ([]*Device, error) {
 }
 
 func getDeviceNodes(path string) ([]*Device, error) {
-	files, err := ioutil.ReadDir(path)
+	files, err := ioutilReadDir(path)
 	if err != nil {
 		return nil, err
 	}

--- a/devices/devices_test.go
+++ b/devices/devices_test.go
@@ -19,3 +19,43 @@ func TestGetDeviceLstatFailure(t *testing.T) {
 		t.Fatalf("Unexpected error %v, expected %v", err, testError)
 	}
 }
+
+func TestGetHostDeviceNodesIoutilReadDirFailure(t *testing.T) {
+	testError := errors.New("test error")
+
+	// Override ioutil.ReadDir to inject error.
+	ioutilReadDir = func(dirname string) ([]os.FileInfo, error) {
+		return nil, testError
+	}
+
+	_, err := GetHostDeviceNodes()
+	if err != testError {
+		t.Fatalf("Unexpected error %v, expected %v", err, testError)
+	}
+}
+
+func TestGetHostDeviceNodesIoutilReadDirDeepFailure(t *testing.T) {
+	testError := errors.New("test error")
+	called := false
+
+	// Override ioutil.ReadDir to inject error after the first call.
+	ioutilReadDir = func(dirname string) ([]os.FileInfo, error) {
+		if called {
+			return nil, testError
+		}
+		called = true
+
+		// Provoke a second call.
+		fi, err := os.Lstat("/tmp")
+		if err != nil {
+			t.Fatalf("Unexpected error %v", err)
+		}
+
+		return []os.FileInfo{fi}, nil
+	}
+
+	_, err := GetHostDeviceNodes()
+	if err != testError {
+		t.Fatalf("Unexpected error %v, expected %v", err, testError)
+	}
+}


### PR DESCRIPTION
https://github.com/docker/libcontainer/issues/178 requests testing of error paths when external dependencies return errors. This pull request starts to implement this in `devices.go`.

The system interfaces used by `devices.go` are `os`, `io/ioutil`, and `syscall`. The `syscall` usages do not return errors. The usage of `os` is just one function call (`os.Lstat`) and the usage of `io/ioutil` is one function call (`ioutil.ReadDir`) from two call sites.

There are two commits, the first dealing with `os.Lstat` and the second dealing with `ioutil.ReadDir`.

These are very simple tests covering trivial cases, but should establish a pattern that can be used elsewhere.
