### PR TITLE
Using cgroup Parent instead of Slice in systemd.

### DIFF
--- a/api_temp.go
+++ b/api_temp.go
@@ -5,7 +5,6 @@ package libcontainer
 
 import (
 	"github.com/docker/libcontainer/cgroups/fs"
-	"github.com/docker/libcontainer/cgroups/systemd"
 	"github.com/docker/libcontainer/network"
 )
 
@@ -18,12 +17,8 @@ func GetStats(container *Config, state *State) (*ContainerStats, error) {
 		stats = &ContainerStats{}
 	)
 
-	if systemd.UseSystemd() {
-		stats.CgroupStats, err = systemd.GetStats(container.Cgroups)
-	} else {
-		stats.CgroupStats, err = fs.GetStats(container.Cgroups)
-	}
-
+	// TODO(vmarmol): The cgroups are in the state, use that rather than discovering them each time.
+	stats.CgroupStats, err = fs.GetStats(container.Cgroups)
 	if err != nil {
 		return stats, err
 	}

--- a/cgroups/cgroups.go
+++ b/cgroups/cgroups.go
@@ -51,7 +51,6 @@ type Cgroup struct {
 	CpuPeriod         int64             `json:"cpu_period,omitempty"`         // CPU period to be used for hardcapping (in usecs). 0 to use system default.
 	CpusetCpus        string            `json:"cpuset_cpus,omitempty"`        // CPU to use
 	Freezer           FreezerState      `json:"freezer,omitempty"`            // set the freeze value for the process
-	Slice             string            `json:"slice,omitempty"`              // Parent slice to use for systemd
 }
 
 type ActiveCgroup interface {

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -4,9 +4,9 @@ package systemd
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -24,7 +24,6 @@ type systemdCgroup struct {
 }
 
 type subsystem interface {
-	GetStats(string, *cgroups.Stats) error
 }
 
 var (
@@ -86,17 +85,13 @@ func getIfaceForUnit(unitName string) string {
 
 func Apply(c *cgroups.Cgroup, pid int) (cgroups.ActiveCgroup, error) {
 	var (
-		unitName   = getUnitName(c)
-		slice      = "system.slice"
+		unitName   = c.Name
+		slice      = path.Base(c.Parent)
 		properties []systemd.Property
 		res        = &systemdCgroup{}
 	)
 
 	res.cgroup = c
-
-	if c.Slice != "" {
-		slice = c.Slice
-	}
 
 	properties = append(properties,
 		systemd.Property{"Slice", dbus.MakeVariant(slice)},
@@ -217,12 +212,7 @@ func getSubsystemPath(c *cgroups.Cgroup, subsystem string) (string, error) {
 		return "", err
 	}
 
-	slice := "system.slice"
-	if c.Slice != "" {
-		slice = c.Slice
-	}
-
-	return filepath.Join(mountpoint, initPath, slice, getUnitName(c)), nil
+	return filepath.Join(mountpoint, initPath, c.Parent, c.Name), nil
 }
 
 func Freeze(c *cgroups.Cgroup, state cgroups.FreezerState) error {
@@ -254,39 +244,6 @@ func GetPids(c *cgroups.Cgroup) ([]int, error) {
 	}
 
 	return cgroups.ReadProcsFile(path)
-}
-
-func getUnitName(c *cgroups.Cgroup) string {
-	return fmt.Sprintf("%s-%s.scope", c.Parent, c.Name)
-}
-
-/*
- * This would be nicer to get from the systemd API when accounting
- * is enabled, but sadly there is no way to do that yet.
- * The lack of this functionality in the API & the approach taken
- * is guided by
- * http://www.freedesktop.org/wiki/Software/systemd/ControlGroupInterface/#readingaccountinginformation.
- */
-func GetStats(c *cgroups.Cgroup) (*cgroups.Stats, error) {
-	stats := cgroups.NewStats()
-
-	for sysname, sys := range subsystems {
-		subsystemPath, err := getSubsystemPath(c, sysname)
-		if err != nil {
-			// Don't fail if a cgroup hierarchy was not found, just skip this subsystem
-			if cgroups.IsNotFound(err) {
-				continue
-			}
-
-			return nil, err
-		}
-
-		if err := sys.GetStats(subsystemPath, stats); err != nil {
-			return nil, err
-		}
-	}
-
-	return stats, nil
 }
 
 // Atm we can't use the systemd device support because of two missing things:


### PR DESCRIPTION
We originally exposed Slice. Now that we understand systemd's handling
of cgroups, it seems more appropriate to use Parent.

Fixes #198.

Docker-DCO-1.1-Signed-off-by: Victor Marmol vmarmol@google.com (github: vmarmol)
