### PR TITLE
Adding IPv6 network support

### DIFF
--- a/network/types.go
+++ b/network/types.go
@@ -20,14 +20,14 @@ type Network struct {
 	// Address contains the IPv4 and mask to set on the network interface
 	Address string `json:"address,omitempty"`
 
-	// Address contains the IPv6 and mask to set on the network interface
-	Address6 string `json:"address6,omitempty"`
+	// IPv6Address contains the IPv6 and mask to set on the network interface
+	IPv6Address string `json:"ipv6_address,omitempty"`
 
 	// Gateway sets the gateway address that is used as the default for the interface
 	Gateway string `json:"gateway,omitempty"`
 
-	// Gateway sets the ipv6 gateway address that is used as the default for the interface
-	Gateway6 string `json:"gateway6,omitempty"`
+	// IPv6Gateway sets the ipv6 gateway address that is used as the default for the interface
+	IPv6Gateway string `json:"ipv6_gateway,omitempty"`
 
 	// Mtu sets the mtu value for the interface and will be mirrored on both the host and
 	// container's interfaces if a pair is created, specifically in the case of type veth

--- a/network/veth.go
+++ b/network/veth.go
@@ -63,8 +63,8 @@ func (v *Veth) Initialize(config *Network, networkState *NetworkState) error {
 	if err := SetInterfaceIp(defaultDevice, config.Address); err != nil {
 		return fmt.Errorf("set %s ip %s", defaultDevice, err)
 	}
-	if config.Address6 != "" {
-		if err := SetInterfaceIp(defaultDevice, config.Address6); err != nil {
+	if config.IPv6Address != "" {
+		if err := SetInterfaceIp(defaultDevice, config.IPv6Address); err != nil {
 			return fmt.Errorf("set %s ipv6 %s", defaultDevice, err)
 		}
 	}
@@ -80,9 +80,9 @@ func (v *Veth) Initialize(config *Network, networkState *NetworkState) error {
 			return fmt.Errorf("set gateway to %s on device %s failed with %s", config.Gateway, defaultDevice, err)
 		}
 	}
-	if config.Gateway6 != "" {
-		if err := SetDefaultGateway(config.Gateway6, defaultDevice); err != nil {
-			return fmt.Errorf("set gateway for ipv6 to %s on device %s failed with %s", config.Gateway6, defaultDevice, err)
+	if config.IPv6Gateway != "" {
+		if err := SetDefaultGateway(config.IPv6Gateway, defaultDevice); err != nil {
+			return fmt.Errorf("set gateway for ipv6 to %s on device %s failed with %s", config.IPv6Gateway, defaultDevice, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
While implementing IPv6 support for docker I have noticed that one veth device can only be created with one IPv4 address. I have added an IPv6 address and gateway to network/types.go and extended the Initialize function in network/veth.go to register the IPv6 address and gateway if they are provided.
