### PR TITLE
Add checkpoint/restore functionality to nsinit and libcontainer

### DIFF
--- a/namespaces/checkpoint.go
+++ b/namespaces/checkpoint.go
@@ -1,0 +1,40 @@
+package namespaces
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"strconv"
+
+	"github.com/docker/libcontainer"
+)
+
+const (
+	CheckpointLog = "dump.log"
+	RestoreLog    = "restore.log"
+)
+
+// Checkpoint the specified container using the criu(8) utility.
+func Checkpoint(criuBinary string, container *libcontainer.Config, imageDir string, initPid int, verbose bool) error {
+	// Prepare command line arguments.
+	args := []string{
+		"dump", "-v4",
+		"-D", imageDir, "-o", CheckpointLog,
+		"--root", container.RootFs,
+		"--manage-cgroups", "--evasive-devices",
+		"-t", strconv.Itoa(initPid),
+	}
+	for _, mountpoint := range container.MountConfig.Mounts {
+		args = append(args, "--ext-mount-map", fmt.Sprintf("%s:%s", mountpoint.Destination, mountpoint.Destination))
+	}
+
+	// Execute criu to checkpoint.
+	if verbose {
+		log.Printf("Running CRIU: %s %v\n", criuBinary, args)
+	}
+	output, err := exec.Command(criuBinary, args...).CombinedOutput()
+	if verbose && len(output) > 0 {
+		log.Printf("%s\n", output)
+	}
+	return err
+}

--- a/namespaces/restore.go
+++ b/namespaces/restore.go
@@ -1,0 +1,34 @@
+package namespaces
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+
+	"github.com/docker/libcontainer"
+)
+
+// Restore the specified container (previously checkpointed) using the
+// criu(8) utility.
+func Restore(criuBinary string, container *libcontainer.Config, imageDir string, verbose bool) error {
+	// Prepare command line arguments.
+	args := []string{
+		"restore", "-d", "-v4",
+		"-D", imageDir, "-o", RestoreLog,
+		"--root", container.RootFs,
+		"--manage-cgroups", "--evasive-devices",
+	}
+	for _, mountpoint := range container.MountConfig.Mounts {
+		args = append(args, "--ext-mount-map", fmt.Sprintf("%s:%s", mountpoint.Destination, mountpoint.Source))
+	}
+
+	// Execute criu to restore.
+	if verbose {
+		log.Printf("Running CRIU: %s %v\n", criuBinary, args)
+	}
+	output, err := exec.Command(criuBinary, args...).CombinedOutput()
+	if verbose && len(output) > 0 {
+		log.Printf("%s\n", output)
+	}
+	return err
+}

--- a/nsinit/checkpoint.go
+++ b/nsinit/checkpoint.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/codegangsta/cli"
+	"github.com/docker/libcontainer"
+)
+
+var checkpointDescription string = `Checkpoint a process tree running in a container with the criu(8)
+   utility.
+
+   The container ID is determined by one of the following three methods
+   in the order described:
+
+      1. Command line argument
+      2. Last pathname component of the data_path environment variable
+      3. Last pathname component of the current working directory
+
+   If method 1 is used, the libcontainer's home directory must be
+   specified in the LIBCONTAINER_DIR environment variable.
+
+   Nsinit expects to find the container's container.json and state.json
+   files in the container subdirectory of the libcontainer's home
+   directory.
+
+   The user has to specify an image home directory for criu(8) by setting
+   the CRIU_IMG_HOME_DIR environment variable.  Within this directory,
+   a container's image files will be saved in <container_id>/criu_img
+   subdirectory.
+
+   Returns 0 on success.  On error, prints an error message and returns
+   a non-zero code.
+
+ENVIRONMENT:
+   CRIU_BINARY          criu binary to execute, if not set "criu" is assumed
+   CRIU_IMG_HOME_DIR    criu image home directory
+   LIBCONTAINER_DIR     libcontainer home directory
+   data_path            directory pathname of container.json (no trailing /)
+   log                  pathname where to log
+
+EXAMPLE:
+   # export LIBCONTAINER_DIR=/var/lib/docker/execdriver/native
+   # export CRIU_IMG_HOME_DIR=/var/lib/docker/containers
+   # docker ps -lq --no-trunc
+   281ab0098269e515e3f81661c3cd6272abb640cf352efc64b3b98cc2470f3944
+   # nsinit checkpoint 281ab0098269e515e3f81661c3cd6272abb640cf352efc64b3b98cc2470f3944
+   checkpoint succeeded
+   # `
+
+var checkpointCommand = cli.Command{
+	Name:        "checkpoint",
+	Usage:       "checkpoint a container",
+	Action:      checkpointAction,
+	Description: checkpointDescription,
+	Flags: []cli.Flag{
+		cli.BoolFlag{Name: "verbose, v", Usage: "enable verbose mode"},
+	},
+}
+
+func checkpointAction(context *cli.Context) {
+	if len(context.Args()) > 1 {
+		log.Fatal("Too many command line arguments\n")
+	}
+
+	// Get container ID and set dataPath if needed.
+	containerId := getContainerId(context)
+
+	// Load the container.json file to verify that we have
+	// a valid container.
+	container, err := loadConfig()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Get the init PID of the process tree from state.json.
+	state, err := libcontainer.GetState(dataPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	initPid := state.InitPid
+	if initPid == 0 {
+		log.Fatal("Container's init PID is uninitialized\n")
+	}
+
+	// Create an image directory for this container (which
+	// may already exist from a previous checkpoint).
+	imageDir := getImageDir(containerId)
+	err = os.MkdirAll(imageDir, 0700)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Copy container.json in the criu image directory for
+	// later use during restore.
+	copyFile(filepath.Join(dataPath, "container.json"), filepath.Join(imageDir, "container.json"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Run criu and exit on error because our caller doesn't take return value.
+	err = runCriu(context, container, containerId, imageDir, initPid)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/nsinit/cr_common.go
+++ b/nsinit/cr_common.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/codegangsta/cli"
+	"github.com/docker/libcontainer"
+	"github.com/docker/libcontainer/namespaces"
+)
+
+// Refer to the description message at the beginning of this file to
+// see how we get the container ID.
+func getContainerId(context *cli.Context) string {
+	if len(context.Args()) == 1 {
+		// dataPath may have been initialized from data_path if
+		// in environment (if it was set).  But if a container
+		// ID is specified on the command line, dataPath will be
+		// reinitialized here from LIBCONTAINER_DIR environment
+		// variable and the specified container ID.
+		containerId := context.Args()[0]
+		if libcontainerDir == "" {
+			log.Fatal("LIBCONTAINER_DIR not set")
+		}
+		dataPath = filepath.Join(libcontainerDir, containerId)
+		return containerId
+	}
+
+	if dataPath == "" {
+		// If the container has been checkpointed, the directory
+		// where its container.json file existed has been removed.
+		// So for restore, we cannot get the container ID from
+		// the cwd pathname.
+		if context.Command.Name == "restore" {
+			log.Fatal("Specify container ID as an argument or set data_path env var")
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			log.Fatal(err)
+		}
+		dataPath = cwd
+	}
+
+	// Extract container ID from the pathname.
+	containerId := filepath.Base(dataPath)
+	if containerId == "" {
+		log.Fatal("Cannot determine container ID")
+	}
+
+	return containerId
+}
+
+// Return the directory pathname where CRIU should save and retrieve
+// its image files.
+func getImageDir(containerId string) string {
+	p := os.Getenv("CRIU_IMG_HOME_DIR")
+	if p == "" {
+		log.Fatal("CRIU_IMG_HOME_DIR not set")
+	}
+	return filepath.Join(p, containerId, "criu_img")
+}
+
+// Common code for checkpoint and restore.
+func runCriu(context *cli.Context, container *libcontainer.Config, containerId, imageDir string, initPid int) error {
+	verbose := context.Bool("verbose")
+	cmd := context.Command.Name
+
+	criuBinary := os.Getenv("CRIU_BINARY")
+	if criuBinary == "" {
+		criuBinary = "criu"
+	}
+
+	var err error
+	if cmd == "checkpoint" {
+		err = namespaces.Checkpoint(criuBinary, container, imageDir, initPid, verbose)
+	} else {
+		err = namespaces.Restore(criuBinary, container, imageDir, verbose)
+	}
+	if !verbose {
+		return err
+	}
+
+	if err == nil {
+		fmt.Printf("%s succeeded\n", cmd)
+	} else {
+		fmt.Printf("%s failed: %s\n", cmd, err)
+		var logFile string
+		if cmd == "checkpoint" {
+			logFile = filepath.Join(imageDir, namespaces.CheckpointLog)
+		} else {
+			logFile = filepath.Join(imageDir, namespaces.RestoreLog)
+		}
+		fmt.Printf("Cause of failure may be in %s\n", logFile)
+	}
+	return err
+}

--- a/nsinit/init.go
+++ b/nsinit/init.go
@@ -12,9 +12,10 @@ import (
 )
 
 var (
-	dataPath  = os.Getenv("data_path")
-	console   = os.Getenv("console")
-	rawPipeFd = os.Getenv("pipe")
+	dataPath        = os.Getenv("data_path")
+	console         = os.Getenv("console")
+	rawPipeFd       = os.Getenv("pipe")
+	libcontainerDir = os.Getenv("LIBCONTAINER_DIR")
 
 	initCommand = cli.Command{
 		Name:   "init",

--- a/nsinit/main.go
+++ b/nsinit/main.go
@@ -43,7 +43,7 @@ func main() {
 	app := cli.NewApp()
 
 	app.Name = "nsinit"
-	app.Version = "0.1"
+	app.Version = "0.2"
 	app.Author = "libcontainer maintainers"
 	app.Flags = []cli.Flag{
 		cli.StringFlag{Name: "nspid"},
@@ -59,6 +59,8 @@ func main() {
 		configCommand,
 		pauseCommand,
 		unpauseCommand,
+		checkpointCommand,
+		restoreCommand,
 	}
 
 	if err := app.Run(os.Args); err != nil {

--- a/nsinit/restore.go
+++ b/nsinit/restore.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/codegangsta/cli"
+	"github.com/docker/docker/pkg/mount"
+	"github.com/docker/libcontainer"
+)
+
+var restoreDescription string = `Restore a process tree in a container previously checkpointed with
+   the criu(8) utility.
+
+   The container ID is determined by one of the following two methods
+   in the order described:
+
+      1. Command line arugment
+      2. Last pathname component of the data_path environment variable
+
+   If method 1 is used, the libcontainer's home directory must be
+   specified in the LIBCONTAINER_DIR environment variable.
+
+   The user has to specify an image home directory by setting the
+   CRIU_IMG_HOME_DIR environment variable.  Within this directory,
+   nsinit expects to find the container's image files saved by criu(8)
+   in the <container_id>/criu_img subdirectory.
+
+   Restore currently assumes that it's restoring a container using the
+   AUFS filesystem.  As such, it expects to find an AUFS directory tree
+   at "../../aufs" relative to LIBCONTAINER_DIR.  Support for other
+   filesystems types such as VFS and UnionFS can be added on a need basis.
+
+   Returns 0 on success.  On error, prints an error message and returns
+   a non-zero code.
+
+ENVIRONMENT:
+   CRIU_BINARY          criu binary to execute, if not set "criu" is assumed
+   CRIU_IMG_HOME_DIR    criu image home directory
+   LIBCONTAINER_DIR     libcontainer home directory
+   data_path            directory pathname of container.json (no trailing /)
+   log                  pathname where to log
+
+EXAMPLE:
+   # export LIBCONTAINER_DIR=/var/lib/docker/execdriver/native
+   # export CRIU_IMG_HOME_DIR=/var/lib/docker/containers
+   # docker ps -a -lq --no-trunc
+   281ab0098269e515e3f81661c3cd6272abb640cf352efc64b3b98cc2470f3944
+   # nsinit restore 281ab0098269e515e3f81661c3cd6272abb640cf352efc64b3b98cc2470f3944
+   restore succeeded
+   # `
+
+var restoreCommand = cli.Command{
+	Name:        "restore",
+	Usage:       "restore a container",
+	Action:      restoreAction,
+	Description: restoreDescription,
+	Flags: []cli.Flag{
+		cli.BoolFlag{Name: "verbose, v", Usage: "enable verbose mode"},
+	},
+}
+
+func restoreAction(context *cli.Context) {
+	if len(context.Args()) > 1 {
+		log.Fatal("Too many command line arguments\n")
+	}
+
+	// Get container ID and set dataPath if needed.
+	containerId := getContainerId(context)
+
+	// If there is a state.json file, the container already exists.
+	state, err := libcontainer.GetState(dataPath)
+	if err == nil {
+		log.Fatalf("Container already running (check pid %d)", state.InitPid)
+	}
+
+	// Decode container.json in the criu image directory
+	// that was saved there during checkpoint.  We need to
+	// get external bind mount paths from it.
+	imageDir := getImageDir(containerId)
+	f, err := os.Open(filepath.Join(imageDir, "container.json"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	var container *libcontainer.Config
+	err = json.NewDecoder(f).Decode(&container)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Mount the container's filesystem if it's not already mounted.
+	if !rootFsMounted(container) {
+		// NOTE: Because the container's filesystem type is not
+		//       specified in either container.json or state.json,
+		//       we assume here that it's the default AUFS.  If
+		//       using other filesystem types (VFS, UnionFS, etc.),
+		//       for now make sure that it's already mounted.
+		//       Support will be added in a subsequent commit.
+		err = mountAufsRoot(containerId, container.RootFs, context.Bool("verbose"))
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	// Run criu and exit on error because our caller doesn't take return value.
+	err = runCriu(context, container, containerId, imageDir, 0)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func rootFsMounted(container *libcontainer.Config) bool {
+	mountInfos, err := mount.GetMounts()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, mount := range mountInfos {
+		if mount.Mountpoint == container.RootFs {
+			return true
+		}
+	}
+	return false
+}
+
+func mountAufsRoot(containerId, rootFs string, verbose bool) error {
+	aufsDir := filepath.Join(libcontainerDir, "../../aufs")
+
+	// Read filesystem's AUFS branch IDs.
+	f, err := os.Open(filepath.Join(aufsDir, "layers", containerId))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	aufsBranches := filepath.Join(aufsDir, "diff", containerId)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		aufsBranches = fmt.Sprintf("%s:%s", aufsBranches, filepath.Join(aufsDir, "diff", scanner.Text()))
+	}
+	err = scanner.Err()
+	if err != nil {
+		return err
+	}
+
+	// Build the command line.
+	args := []string{"-t", "aufs", "-o", "br=" + aufsBranches, "none", rootFs}
+
+	// Mount the container's filesystem.
+	cmd := "mount"
+	if verbose {
+		log.Printf("%s %v\n", cmd, args)
+	}
+	output, err := exec.Command(cmd, args...).CombinedOutput()
+	if verbose && len(output) > 0 {
+		log.Printf("%s\n", output)
+	}
+	return err
+}

--- a/nsinit/utils.go
+++ b/nsinit/utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -91,4 +92,21 @@ func runFunc(f *rFunc) {
 	}
 
 	f.Action(config, userArgs)
+}
+
+func copyFile(srcFile, dstFile string) error {
+	src, err := os.Open(srcFile)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	dst, err := os.Create(dstFile)
+	if err != nil {
+		return err
+	}
+	defer dst.Close()
+
+	_, err = io.Copy(dst, src)
+	return err
 }


### PR DESCRIPTION
New code was added to nsinit and libcontainer to use the criu(8) utility
to checkpoint and restore a container.

While there are no hard-coded assumptions about Docker, the new C/R
functionality has only been tested with Docker containers.

The nsinit command line usage for checkpoint and restore is consistent
with the rest of nsinit commands.  However, for easier C/R usage, the
user can specify the container ID on the command line.  The best way
to get started is to run "nsinit checkpoint --help" and look at the
"EXAMPLE:" section.

Signed-off-by: Saied Kazemi <saied@google.com>