### PR TITLE
Added support for VLAN and MAC VLAN interfaces plus did a bit of refactoring.

### DIFF
--- a/netlink/netlink_linux_test.go
+++ b/netlink/netlink_linux_test.go
@@ -200,6 +200,54 @@ func TestNetworkChangeName(t *testing.T) {
 	deleteLink(t, newName)
 }
 
+func TestNetworkLinkAddVlan(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	tl := struct {
+		name string
+		id   uint16
+	}{
+		name: "tstVlan",
+		id:   32,
+	}
+	masterLink := testLink{"tstEth", "dummy"}
+
+	addLink(t, masterLink.name, masterLink.linkType)
+	defer deleteLink(t, masterLink.name)
+
+	if err := NetworkLinkAddVlan(masterLink.name, tl.name, tl.id); err != nil {
+		t.Fatalf("Unable to create %#v VLAN interface: %s", tl, err)
+	}
+
+	readLink(t, tl.name)
+}
+
+func TestNetworkLinkAddMacVlan(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+
+	tl := struct {
+		name string
+		mode string
+	}{
+		name: "tstVlan",
+		mode: "private",
+	}
+	masterLink := testLink{"tstEth", "dummy"}
+
+	addLink(t, masterLink.name, masterLink.linkType)
+	defer deleteLink(t, masterLink.name)
+
+	if err := NetworkLinkAddMacVlan(masterLink.name, tl.name, tl.mode); err != nil {
+		t.Fatalf("Unable to create %#v MAC VLAN interface: %s", tl, err)
+	}
+
+	readLink(t, tl.name)
+}
+
 func TestAddDelNetworkIp(t *testing.T) {
 	if testing.Short() {
 		return
@@ -252,7 +300,7 @@ func TestCreateVethPair(t *testing.T) {
 }
 
 //
-// netlink package test which do not use RTNETLINK
+// netlink package tests which do not use RTNETLINK
 //
 func TestCreateBridgeWithMac(t *testing.T) {
 	if testing.Short() {


### PR DESCRIPTION
You can now create both VLAN and MAC VLAN interfaces using netlink! :+1: I've also added tests which cover the newly added functionality.

On top of that, this PR ships 
- reworked `NetworkChangeName` function from the original implementation which was using `syscall`s to the one which communicates with Kernel via `netlink`. I kept the original implementation at the bottom of the source file, though I renamed it so it's clear that it does not use `netlink`  - the name of the function does not have "Network" prefix any more.
- refactored `NetworkNs` functions - both for `PID` and `FD` cases. I tried to be consistent with what we have started with the "IP" addition and deletion
