### PR TITLE
Allow IPC namespace to be shared between containers or with the host

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ sh:
 GO_PACKAGES = $(shell find . -not \( -wholename ./vendor -prune -o -wholename ./.git -prune \) -name '*.go' -print0 | xargs -0n1 dirname | sort -u)
 
 direct-test:
-	go test -cover -v $(GO_PACKAGES)
+	go test $(TEST_TAGS) -cover -v $(GO_PACKAGES)
 
 direct-test-short:
-	go test -cover -test.short -v $(GO_PACKAGES)
+	go test $(TEST_TAGS) -cover -test.short -v $(GO_PACKAGES)
 
 direct-build:
 	go build -v $(GO_PACKAGES)

--- a/config.go
+++ b/config.go
@@ -47,6 +47,9 @@ type Config struct {
 	// Networks specifies the container's network setup to be created
 	Networks []*Network `json:"networks,omitempty"`
 
+	// Ipc specifies the container's ipc setup to be created
+	IpcNsPath string `json:"ipc,omitempty"`
+
 	// Routes can be specified to create entries in the route table as the container is started
 	Routes []*Route `json:"routes,omitempty"`
 

--- a/ipc/ipc.go
+++ b/ipc/ipc.go
@@ -1,0 +1,31 @@
+package ipc
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/docker/libcontainer/system"
+)
+
+// Join the IPC Namespace of specified ipc path if it exists.
+// If the path does not exist then you are not joining a container.
+func Initialize(nsPath string) error {
+
+	if nsPath == "" {
+		return nil
+	}
+	f, err := os.OpenFile(nsPath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed get IPC namespace fd: %v", err)
+	}
+
+	err = system.Setns(f.Fd(), syscall.CLONE_NEWIPC)
+	f.Close()
+
+	if err != nil {
+		return fmt.Errorf("failed to setns current IPC namespace: %v", err)
+	}
+
+	return nil
+}

--- a/namespaces/init.go
+++ b/namespaces/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/docker/libcontainer"
 	"github.com/docker/libcontainer/apparmor"
 	"github.com/docker/libcontainer/console"
+	"github.com/docker/libcontainer/ipc"
 	"github.com/docker/libcontainer/label"
 	"github.com/docker/libcontainer/mount"
 	"github.com/docker/libcontainer/netlink"
@@ -65,6 +66,9 @@ func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, syn
 		if err := system.Setctty(); err != nil {
 			return fmt.Errorf("setctty %s", err)
 		}
+	}
+	if err := ipc.Initialize(container.IpcNsPath); err != nil {
+		return fmt.Errorf("setup IPC %s", err)
 	}
 	if err := setupNetwork(container, networkState); err != nil {
 		return fmt.Errorf("setup networking %s", err)


### PR DESCRIPTION
Some workloads rely on IPC for communications with other processes.  We
would like to split workloads between two container but still allow them
to communicate though shared IPC.

This patch allows us to mimic the --net code to allow --ipc=host to not split off
the IPC Namespace.  ipc=container:CONTAINERID to share ipc between containers

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
