### PR TITLE
Make joinDevices public.

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -73,6 +73,19 @@ func Apply(c *cgroups.Cgroup, pid int) (cgroups.ActiveCgroup, error) {
 	return d, nil
 }
 
+// Symmetrical public function to update device based cgroups.  Also available
+// in the systemd implementation.
+func ApplyDevices(c *cgroups.Cgroup, pid int) error {
+	d, err := getCgroupData(c, pid)
+	if err != nil {
+		return err
+	}
+
+	devices := subsystems["devices"]
+
+	return devices.Set(d)
+}
+
 func Cleanup(c *cgroups.Cgroup) error {
 	d, err := getCgroupData(c, 0)
 	if err != nil {

--- a/cgroups/systemd/apply_nosystemd.go
+++ b/cgroups/systemd/apply_nosystemd.go
@@ -20,6 +20,10 @@ func GetPids(c *cgroups.Cgroup) ([]int, error) {
 	return nil, fmt.Errorf("Systemd not supported")
 }
 
+func ApplyDevices(c *cgroups.Cgroup, pid int) error {
+	return fmt.Errorf("Systemd not supported")
+}
+
 func Freeze(c *cgroups.Cgroup, state cgroups.FreezerState) error {
 	return fmt.Errorf("Systemd not supported")
 }

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -327,6 +327,12 @@ func joinDevices(c *cgroups.Cgroup, pid int) error {
 	return nil
 }
 
+// Symmetrical public function to update device based cgroups.  Also available
+// in the fs implementation.
+func ApplyDevices(c *cgroups.Cgroup, pid int) error {
+	return joinDevices(c, pid)
+}
+
 func joinMemory(c *cgroups.Cgroup, pid int) error {
 	memorySwap := c.MemorySwap
 


### PR DESCRIPTION
For our work on adding dynamic device support to Docker we needed to be
able to call this to update the list of allowed devices.

Co-Authored-By: Chris Alfonso calfonso@redhat.com (github: calfonso)
Docker-DCO-1.1-Signed-off-by: Ian Main imain@redhat.com (github: imain)
