### PR TITLE
Fix "go install -v . ./.git/logs/refs/heads ./.git/refs/heads ..."

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 sh:
 	docker run --rm -it --privileged -w /busybox docker/libcontainer nsinit exec sh
 
-GO_PACKAGES = $(shell find . -not \( -wholename ./vendor -prune \) -name '*.go' -print0 | xargs -0n1 dirname | sort -u)
+GO_PACKAGES = $(shell find . -not \( -wholename ./vendor -prune -o -wholename ./.git -prune \) -name '*.go' -print0 | xargs -0n1 dirname | sort -u)
 
 direct-test:
 	go test -cover -v $(GO_PACKAGES)


### PR DESCRIPTION
This happens when you name a git object (branch, tag, etc) `something_test.go`.
