### PR TITLE
2014 10 03 dummy net strategy signed

### DIFF
--- a/network/dummy.go
+++ b/network/dummy.go
@@ -1,0 +1,62 @@
+// +build linux
+
+package network
+
+import (
+	"fmt"
+
+	"github.com/docker/libcontainer/netlink"
+)
+
+type Dummy struct {
+}
+
+func (d *Dummy) Create(n *Network, nspid int, networkState *NetworkState) error {
+	name := n.DummyName
+	if name == "" {
+		return fmt.Errorf("dummy interface name is not specified")
+	}
+
+	if err := netlink.NetworkLinkAdd(name, "dummy"); err != nil {
+		return fmt.Errorf("Unable to create dummy interface %s: %s", name, err)
+	}
+	if err := InterfaceUp(name); err != nil {
+		return err
+	}
+	if err := SetInterfaceInNamespacePid(name, nspid); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *Dummy) Initialize(config *Network, networkState *NetworkState) error {
+	name := config.DummyName
+	if name == "" {
+		return fmt.Errorf("dummy interface name is not specified")
+	}
+
+	if err := InterfaceDown(name); err != nil {
+		return fmt.Errorf("interface down %s %s", name, err)
+	}
+	if config.MacAddress != "" {
+		if err := SetInterfaceMac(name, config.MacAddress); err != nil {
+			return fmt.Errorf("set %s mac %s", name, err)
+		}
+	}
+	if err := SetInterfaceIp(name, config.Address); err != nil {
+		return fmt.Errorf("set %s ip %s", name, err)
+	}
+	if config.IPv6Address != "" {
+		if err := SetInterfaceIp(name, config.IPv6Address); err != nil {
+			return fmt.Errorf("set %s ipv6 %s", name, err)
+		}
+	}
+	if err := SetMtu(name, config.Mtu); err != nil {
+		return fmt.Errorf("set %s mtu to %d %s", name, config.Mtu, err)
+	}
+	if err := InterfaceUp(name); err != nil {
+		return fmt.Errorf("%s up %s", name, err)
+	}
+	return nil
+}

--- a/network/strategy.go
+++ b/network/strategy.go
@@ -14,6 +14,7 @@ var strategies = map[string]NetworkStrategy{
 	"veth":     &Veth{},
 	"loopback": &Loopback{},
 	"netns":    &NetNS{},
+	"dummy":    &Dummy{},
 }
 
 // NetworkStrategy represents a specific network configuration for

--- a/network/types.go
+++ b/network/types.go
@@ -17,6 +17,9 @@ type Network struct {
 	// Prefix for the veth interfaces.
 	VethPrefix string `json:"veth_prefix,omitempty"`
 
+	// Name of the dummy interface.
+	DummyName string `json:"dummy_name,omitempty"`
+
 	// MacAddress contains the MAC address to set on the network interface
 	MacAddress string `json:"mac_address,omitempty"`
 

--- a/sample_configs/dummy-network.json
+++ b/sample_configs/dummy-network.json
@@ -1,0 +1,207 @@
+{
+    "capabilities": [
+        "CHOWN",
+        "DAC_OVERRIDE",
+        "FOWNER",
+        "MKNOD",
+        "NET_RAW",
+        "SETGID",
+        "SETUID",
+        "SETFCAP",
+        "SETPCAP",
+        "NET_BIND_SERVICE",
+        "SYS_CHROOT",
+        "KILL"
+    ],
+    "cgroups": {
+        "allowed_devices": [
+            {
+                "cgroup_permissions": "m",
+                "major_number": -1,
+                "minor_number": -1,
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "m",
+                "major_number": -1,
+                "minor_number": -1,
+                "type": 98
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "major_number": 5,
+                "minor_number": 1,
+                "path": "/dev/console",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "major_number": 4,
+                "path": "/dev/tty0",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "major_number": 4,
+                "minor_number": 1,
+                "path": "/dev/tty1",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "major_number": 136,
+                "minor_number": -1,
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "major_number": 5,
+                "minor_number": 2,
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "major_number": 10,
+                "minor_number": 200,
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 1,
+                "minor_number": 3,
+                "path": "/dev/null",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 1,
+                "minor_number": 5,
+                "path": "/dev/zero",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 1,
+                "minor_number": 7,
+                "path": "/dev/full",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 5,
+                "path": "/dev/tty",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 1,
+                "minor_number": 9,
+                "path": "/dev/urandom",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 1,
+                "minor_number": 8,
+                "path": "/dev/random",
+                "type": 99
+            }
+        ],
+        "name": "docker-dummytest",
+        "parent": "docker"
+    },
+    "restrict_sys": true,
+    "mount_config": {
+        "device_nodes": [
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 1,
+                "minor_number": 3,
+                "path": "/dev/null",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 1,
+                "minor_number": 5,
+                "path": "/dev/zero",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 1,
+                "minor_number": 7,
+                "path": "/dev/full",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 5,
+                "path": "/dev/tty",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 1,
+                "minor_number": 9,
+                "path": "/dev/urandom",
+                "type": 99
+            },
+            {
+                "cgroup_permissions": "rwm",
+                "file_mode": 438,
+                "major_number": 1,
+                "minor_number": 8,
+                "path": "/dev/random",
+                "type": 99
+            }
+        ],
+        "mounts": [
+            {
+                "type": "tmpfs",
+                "destination": "/tmp"
+            }
+        ]
+    },
+    "environment": [
+        "HOME=/",
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "HOSTNAME=dummytest",
+        "TERM=xterm"
+    ],
+    "hostname": "dummytest",
+    "namespaces": {
+        "NEWIPC": true,
+        "NEWNET": true,
+        "NEWNS": true,
+        "NEWPID": true,
+        "NEWUTS": true
+    },
+    "networks": [
+        {
+            "address": "127.0.0.1/0",
+            "gateway": "localhost",
+            "mtu": 1500,
+            "type": "loopback"
+        },
+        {
+            "address": "169.254.169.254/32",
+            "dummy_name": "dummy0",
+            "mtu": 1500,
+            "type": "dummy"
+        }
+    ],
+    "tty": true,
+    "user": "daemon"
+}


### PR DESCRIPTION
I threw this together for some experiments I'm running locally. Submitting this PR in case it's something you want upstream.

The use case I'm working on now is using link-local services to provide an HTTP service for container introspection similar to EC2's metadata API. I'll post separately about this service if it works out.

Another use case is adding a dummy with a fixed (link-local) address that provides host services, such as an HTTP proxy. The container can be started with a dummy interface then varnish/squid/apache/whatever can be bound to the interface using ip netns exec leaving the process invisible to the container but visible on the network with no risk of accidentally linking containers' networks.

My proposal for the metadata API: https://github.com/docker/docker/issues/8427

Edits: add link