### PR TITLE
cgroups: Export ParseCgroupFile

### DIFF
--- a/cgroups/cgroups_test.go
+++ b/cgroups/cgroups_test.go
@@ -20,7 +20,7 @@ const (
 
 func TestParseCgroups(t *testing.T) {
 	r := bytes.NewBuffer([]byte(cgroupsContents))
-	_, err := parseCgroupFile("blkio", r)
+	_, err := ParseCgroupFile("blkio", r)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cgroups/utils.go
+++ b/cgroups/utils.go
@@ -115,7 +115,7 @@ func GetThisCgroupDir(subsystem string) (string, error) {
 	}
 	defer f.Close()
 
-	return parseCgroupFile(subsystem, f)
+	return ParseCgroupFile(subsystem, f)
 }
 
 func GetInitCgroupDir(subsystem string) (string, error) {
@@ -125,7 +125,7 @@ func GetInitCgroupDir(subsystem string) (string, error) {
 	}
 	defer f.Close()
 
-	return parseCgroupFile(subsystem, f)
+	return ParseCgroupFile(subsystem, f)
 }
 
 func ReadProcsFile(dir string) ([]int, error) {
@@ -152,7 +152,7 @@ func ReadProcsFile(dir string) ([]int, error) {
 	return out, nil
 }
 
-func parseCgroupFile(subsystem string, r io.Reader) (string, error) {
+func ParseCgroupFile(subsystem string, r io.Reader) (string, error) {
 	s := bufio.NewScanner(r)
 
 	for s.Scan() {


### PR DESCRIPTION
**Note**: I'm rebasing Josh Poimboeuf's libvirt3 branch on top of docker master, and this commit of his branch would be needed in libcontainer to avoid code duplicates.

This is needed for the libvirt exec driver.

Docker-DCO-1.1-Signed-off-by: Alexander Larsson alexl@redhat.com (github: alexlarsson)
Docker-DCO-1.1-Signed-off-by: Josh Poimboeuf jpoimboe@redhat.com (github: jpoimboe)
