### PR TITLE
[RFC] Initial integration of libct into libcontainer

### DIFF
--- a/libct/mount.go
+++ b/libct/mount.go
@@ -1,0 +1,148 @@
+// +build linux
+
+package libct
+
+import (
+	"fmt"
+	"syscall"
+
+	_libct "github.com/xemul/libct/go"
+	"github.com/docker/libcontainer/devices"
+	"github.com/docker/libcontainer/label"
+	"github.com/docker/libcontainer/mount"
+)
+
+// default mount point flags
+const defaultMountFlags = _libct.CT_FS_NOEXEC | _libct.CT_FS_NOSUID | _libct.CT_FS_NODEV
+
+// TODO: this is crappy right now and should be cleaned up with a better way of handling system and
+// standard bind mounts allowing them to be more dynamic
+func newSystemMounts(mountLabel string, mounts mount.Mounts) []mount_entry {
+	systemMounts := []mount_entry{
+		{source: "proc", path: "/proc", device: "proc", flags: defaultMountFlags},
+		{source: "sysfs", path: "/sys", device: "sysfs", flags: defaultMountFlags},
+		{source: "tmpfs", path: "/dev", device: "tmpfs",
+			flags: _libct.CT_FS_NOSUID | _libct.CT_FS_STRICTATIME,
+			data:  label.FormatMountLabel("mode=755", mountLabel)},
+		{source: "tmpfs", path: "/sys/fs/cgroup", device: "tmpfs", flags: defaultMountFlags},
+		{source: "shm", path: "/dev/shm", device: "tmpfs",
+			flags: defaultMountFlags, data: label.FormatMountLabel("mode=1777,size=65536k", mountLabel)},
+		{source: "devpts", path: "/dev/pts", device: "devpts",
+			flags: _libct.CT_FS_NOSUID | _libct.CT_FS_NOEXEC,
+			data:  label.FormatMountLabel("newinstance,ptmxmode=0666,mode=620,gid=5", mountLabel)},
+	}
+
+	return systemMounts
+}
+
+func setupBindmounts(ct *_libct.Container, rootfs string, mountConfig *mount.MountConfig) error {
+	bindMounts := mountConfig.Mounts
+
+	for _, m := range bindMounts.OfType("bind") {
+		var flags int
+
+		if !m.Writable {
+			flags |= _libct.CT_FS_RDONLY
+		}
+
+		if m.Private {
+			flags |= _libct.CT_FS_PRIVATE
+		}
+
+		if err := ct.AddBindMount(m.Source, m.Destination, flags); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Create the device nodes in the container.
+func createDeviceNodes(ct *_libct.Container, rootfs string, nodesToCreate []*devices.Device) error {
+
+	for _, node := range nodesToCreate {
+		if err := createDeviceNode(ct, rootfs, node); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Creates the device node in the rootfs of the container.
+func createDeviceNode(ct *_libct.Container, rootfs string, node *devices.Device) error {
+	fileMode := node.FileMode
+	switch node.Type {
+	case 'c':
+		fileMode |= syscall.S_IFCHR
+	case 'b':
+		fileMode |= syscall.S_IFBLK
+	default:
+		return fmt.Errorf("%c is not a valid device type for device %s", node.Type, node.Path)
+	}
+
+	err := ct.AddDeviceNode(node.Path, int(fileMode), int(node.MajorNumber), int(node.MinorNumber))
+	if err != nil {
+		return fmt.Errorf("mknod %s %s", node.Path, err)
+	}
+	return nil
+}
+
+type mount_entry struct {
+	source string
+	path   string
+	device string
+	flags  int
+	data   string
+}
+
+// mountSystem sets up linux specific system mounts like sys, proc, shm, and devpts
+// inside the mount namespace
+func mountSystem(ct *_libct.Container, rootfs string, mountConfig *mount.MountConfig) error {
+	for _, m := range newSystemMounts(mountConfig.MountLabel, mountConfig.Mounts) {
+		err := ct.AddMount(m.source, m.path, m.flags, m.device, m.data)
+		if err != nil {
+			return fmt.Errorf("mounting %s into %s %s", m.source, m.path, err)
+		}
+	}
+	return nil
+}
+
+func SetupPtmx(ct *_libct.Container, rootfs, consolePath string) error {
+	if consolePath == "" {
+		return nil
+	}
+
+	dest := "/dev/console"
+
+	if err := ct.AddBindMount(consolePath, dest, 0); err != nil {
+		return fmt.Errorf("bind %s to %s %s", consolePath, dest, err)
+	}
+	return nil
+}
+
+// InitializeMountNamespace setups up the devices, mount points, and filesystems for use inside a
+// new mount namepsace
+func InitializeMountNamespace(ct *_libct.Container, rootfs, console string, mountConfig *mount.MountConfig) error {
+	var (
+		err error
+	)
+
+	if err := mountSystem(ct, rootfs, mountConfig); err != nil {
+		return fmt.Errorf("mount system %s", err)
+	}
+
+	if err = ct.SetRoot(rootfs); err != nil {
+		return fmt.Errorf("bind mounts %s", err)
+	}
+
+	if err := setupBindmounts(ct, rootfs, mountConfig); err != nil {
+		return err
+	}
+	if err := createDeviceNodes(ct, rootfs, mountConfig.DeviceNodes); err != nil {
+		return fmt.Errorf("create device nodes %s", err)
+	}
+
+	if err := SetupPtmx(ct, rootfs, console); err != nil {
+		return err
+	}
+	return nil
+}

--- a/libct/network.go
+++ b/libct/network.go
@@ -1,0 +1,111 @@
+// +build linux
+
+package libct
+
+import (
+	"errors"
+	"fmt"
+
+	_libct "github.com/xemul/libct/go"
+	"github.com/docker/libcontainer/network"
+	"github.com/docker/libcontainer/utils"
+)
+
+var (
+	ErrNotValidStrategyType = errors.New("not a valid network strategy type")
+)
+
+var strategies = map[string]NetworkStrategy{
+	"veth":     &Veth{},
+	"loopback": &Loopback{},
+}
+
+// NetworkStrategy represents a specific network configuration for
+// a container's networking stack
+type NetworkStrategy interface {
+	Create(*_libct.Container, *network.Network, *network.NetworkState) error
+}
+
+// GetStrategy returns the specific network strategy for the
+// provided type.  If no strategy is registered for the type an
+// ErrNotValidStrategyType is returned.
+func GetStrategy(tpe string) (NetworkStrategy, error) {
+	s, exists := strategies[tpe]
+	if !exists {
+		return nil, ErrNotValidStrategyType
+	}
+	return s, nil
+}
+
+// Veth is a network strategy that uses a bridge and creates
+// a veth pair, one that stays outside on the host and the other
+// is placed inside the container's namespace
+type Veth struct {
+}
+
+const defaultDevice = "eth0"
+
+func (v *Veth) Create(ct *_libct.Container, n *network.Network, networkState *network.NetworkState) error {
+	var (
+		bridge = n.Bridge
+		prefix = n.VethPrefix
+	)
+	if bridge == "" {
+		return fmt.Errorf("bridge is not specified")
+	}
+	if prefix == "" {
+		return fmt.Errorf("veth prefix is not specified")
+	}
+	name1, err := utils.GenerateRandomName(prefix, 4)
+	if err != nil {
+		return err
+	}
+	networkState.VethHost = name1
+	networkState.VethChild = defaultDevice
+
+	dev, err := ct.AddNetVeth(name1, defaultDevice)
+	if err != nil {
+		return err
+	}
+
+	if err := dev.SetMtu(n.Mtu); err != nil {
+		return err
+	}
+
+	if err := dev.AddIpAddr(n.Address); err != nil {
+		return err
+	}
+
+	host_dev, err := dev.GetPeer()
+	if err != nil {
+		return err
+	}
+
+	if err := host_dev.SetMaster(bridge); err != nil {
+		return err
+	}
+
+	if n.Gateway != "" {
+		r, err := ct.AddRoute()
+		if err != nil {
+			return err
+		}
+		r.SetDst("default")
+		nh, err := r.AddNextHop()
+		if err != nil {
+			return err
+		}
+		nh.SetDev(defaultDevice)
+		nh.SetGateway(n.Gateway)
+	}
+
+	return nil
+}
+
+// Loopback is a network strategy that provides a basic loopback device
+type Loopback struct {
+}
+
+func (l *Loopback) Create(*_libct.Container, *network.Network, *network.NetworkState) error {
+	return nil
+}

--- a/libct_container.go
+++ b/libct_container.go
@@ -1,0 +1,257 @@
+// +build linux
+
+package libcontainer
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"syscall"
+
+	_libct "github.com/xemul/libct/go"
+	"github.com/docker/libcontainer/libct"
+	"github.com/docker/libcontainer/mount"
+	"github.com/docker/libcontainer/network"
+	"github.com/docker/libcontainer/security/capabilities"
+)
+
+// this is to enforce that the libctContainer conforms to the Container interface at compile time
+var _ Container = (*libctContainer)(nil)
+
+// libctContainer represents a container that can be executed on linux based host machines
+type libctContainer struct {
+	mux sync.Mutex
+
+	// path to the containers state directory
+	path string
+
+	// initial (immutable) config for the container
+	config *Config
+
+	// containers state for the lifetime of the container
+	state *State
+
+	// a map of commands in the order which they were created
+	processes map[int]*Process
+
+	logger *log.Logger
+
+	ct *_libct.Container
+}
+
+func newLibctContainer(config *Config, state *State, logger *log.Logger, ct *_libct.Container) *libctContainer {
+	return &libctContainer{
+		config:    config,
+		state:     state,
+		logger:    logger,
+		processes: make(map[int]*Process),
+		ct: ct,
+	}
+}
+
+// Path returns the path to the container's directory containing the state
+func (c *libctContainer) Path() string {
+	return c.path
+}
+
+// Config returns the initial configuration for the container that was used
+// during initializtion of the container
+func (c *libctContainer) Config() *Config {
+	return c.config
+}
+
+// Status returns the containers current status
+func (c *libctContainer) Status() Status {
+	return c.state.Status
+}
+
+// Stats returns the container's statistics for various cgroup subsystems
+func (c *libctContainer) Stats() (*ContainerStats, error) {
+	c.logger.Printf("reading stats for container: %s\n", c.path)
+
+	panic("not implemented")
+}
+
+// Start runs a new process in the container
+func (c *libctContainer) Start(process *Process) (pid int, exitChan chan int, err error) {
+	c.logger.Printf("starting new process in container: %s\n", c.path)
+
+	panic("not implemented")
+}
+
+// Destroy kills all running process inside the container and cleans up any
+// state left on the filesystem
+func (c *libctContainer) Destroy() error {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if err := c.ct.Kill(); err != nil {
+		return err
+	}
+
+	c.logger.Printf("destroying container: %s\n", c.path)
+
+	c.state.Status = Destroyed
+
+	return nil
+}
+
+// Processes return the PIDs for processes running inside the container
+func (c *libctContainer) Processes() ([]int, error) {
+	panic("not implemented")
+}
+
+// Pause pauses all processes inside the container
+func (c *libctContainer) Pause() error {
+	panic("not implemented")
+}
+
+// Resume unpause all processes inside the container
+func (c *libctContainer) Resume() error {
+	panic("not implemented")
+}
+
+// changeStatus changes the container's current status to s
+// if the state change is not allowed a StateError is returned
+//
+// This method depends on the caller to hold any locks related to the
+// container's state
+func (c *libctContainer) changeStatus(s Status) error {
+
+	c.logger.Printf("container %s changing status from %s to %s\n", c.path, c.state.Status, s)
+
+	c.state.Status = s
+
+	return nil
+}
+
+// getEnabledCapabilities returns the capabilities that should not be dropped by the container.
+func getEnabledCapabilities(capList []string) uint64 {
+	var keep uint64 = 0
+	for _, capability := range capList {
+		if c := capabilities.GetCapability(capability); c != nil {
+			keep |= uint64(c.Value)
+		}
+	}
+	return keep
+}
+
+func dropBoundingSet(ct *_libct.Container, capabilities []string) error {
+	caps := getEnabledCapabilities(capabilities)
+
+	if err := ct.SetCaps(caps, _libct.CAPS_BSET); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *libctContainer) startInitProcess(process *Process) error {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	process.exitChan = make(chan int, 1)
+
+	// because this is our init process we can alwasy set it to 1
+	c.processes[1] = process
+
+	c.logger.Printf("container %s starting init process\n", c.path)
+	if err:= c.ct.SetParentDeathSignal(syscall.SIGKILL); err != nil {
+		return err
+	}
+
+	if err:= dropBoundingSet(c.ct, c.config.Capabilities); err != nil {
+		return err
+	}
+
+	err := c.ct.SetNsMask(uint64(getNamespaceFlags(c.config.Namespaces)))
+	if err != nil {
+		return err
+	}
+
+	if err := libct.InitializeMountNamespace(c.ct, c.config.Rootfs, process.ConsolePath,
+		(*mount.MountConfig)(c.config.MountConfig)); err != nil {
+
+		return err
+	}
+
+	if err := c.setupNetwork(); err != nil {
+		return fmt.Errorf("setup networking %s", err)
+	}
+
+	var fds *[3]uintptr
+	if process.ConsolePath != "" {
+		ttyfd, err := os.OpenFile(process.ConsolePath, os.O_RDWR, 0)
+		if err != nil {
+			return err
+		}
+		fds = &[3]uintptr{ttyfd.Fd(), ttyfd.Fd(), ttyfd.Fd()}
+
+		err = c.ct.SetConsoleFd(ttyfd)
+		if err != nil {
+			return err
+		}
+	} // FIXME proxy pipes
+
+	pid, err := c.ct.SpawnExecve(process.Args[0], process.Args, process.Env, fds)
+	if err != nil {
+		return err
+	}
+
+	p, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	process.cmd.Process = p
+
+	process.pipe.CloseChild()
+
+	startTime, err := process.startTime()
+	if err != nil {
+		process.kill()
+
+		return err
+	}
+
+	// update state
+	c.state.InitPid = process.pid()
+	c.state.InitStartTime = startTime
+
+	c.logger.Printf("container %s init process started at %s with pid %d\n", c.path, c.state.InitStartTime, c.state.InitPid)
+
+	if err := c.changeStatus(Running); err != nil {
+		process.kill()
+
+		return err
+	}
+
+	c.logger.Printf("container %s waiting on init process\n", c.path)
+
+	// finally the users' process should be running inside the container and we did not encounter
+	// any errors during the init of the namespace.  we can now wait on the process and return
+	go func() {
+		process.wait()
+		c.ct.Wait()
+	}()
+
+	return nil
+}
+
+func (c *libctContainer) setupNetwork() error {
+	for _, config := range c.config.Networks {
+		c.logger.Printf("container %s creating network for %s\n", c.path, config.Type)
+
+		strategy, err := libct.GetStrategy(config.Type)
+		if err != nil {
+			return err
+		}
+
+		err = strategy.Create(c.ct, (*network.Network)(config), &c.state.NetworkState)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/libct_factory.go
+++ b/libct_factory.go
@@ -1,0 +1,80 @@
+package libcontainer
+
+import (
+	"log"
+
+	libct "github.com/xemul/libct/go"
+	"github.com/docker/libcontainer/network"
+	"github.com/docker/libcontainer/syncpipe"
+)
+
+type libctFactory struct {
+	initArgs []string
+	logger   *log.Logger
+	session  *libct.Session
+}
+
+func (f *libctFactory) init() error {
+	if f.session != nil {
+		return nil
+	}
+
+	s := &libct.Session{}
+	err := s.OpenLocal()
+	if err != nil {
+		return err
+	}
+
+	f.session = s
+	return nil
+}
+
+func (f *libctFactory) Create(config *Config, initProcess *Process) (Container, error) {
+	if err := f.init(); err != nil {
+		return nil, err
+	}
+
+	state := &State{
+		Status:       Created,
+		NetworkState: network.NetworkState{},
+	}
+
+	f.logger.Println("begin container creation")
+
+	ct, err := f.session.ContainerCreate("docker")
+	if err != nil {
+		return nil, err
+	}
+
+	container := newLibctContainer(config, state, f.logger, ct)
+
+	pipe, err := syncpipe.NewSyncPipe()
+	if err != nil {
+		return nil, err
+	}
+	f.logger.Printf("create syncpipe with parent: %d child: %d\n", pipe.Parent().Fd(), pipe.Child().Fd())
+
+	if err := initProcess.createCommand(f.initArgs, config, pipe); err != nil {
+		return nil, err
+	}
+
+	f.logger.Println("starting init process")
+
+	if err := container.startInitProcess(initProcess); err != nil {
+		return nil, err
+	}
+
+	f.logger.Println("init process started")
+
+	return container, nil
+}
+
+func (f *libctFactory) Load(path string) (Container, error) {
+	panic("not implemented")
+}
+
+// StartInitialization loads a container by opening the pipe fd from the parent to read the configuration and state
+// This is a low level implementation detail of the reexec and should not be consumed externally
+func (f *libctFactory) StartInitialization(pipefd uintptr) (err error) {
+	return nil
+}


### PR DESCRIPTION
Hi All,

I'm integrating libct with libcontainer. I would like to share with you
this early draft to gather your opinions and advices.

This patch adds new factory and container classes to create and manage
containers via LibCT. This version is based on Michael's version of
libcontainer, where is a new api is used.  It has minimal functionality
just to show you how it looks like.

The current version of the abstract interface is a bit different. It
doesn't affect the idea of this patch. I will update the patch as soon
as libcontainer starts using the new interface.

LibCT is a library for creating and managing containers. It has ability
to add different backends. Currently it has only a native backend, which
is the same what libcontainer has now. We are developing a backend for
OpenVZ and PCS.

Notes:
The dockerinit process isn't required for libct. If I understand
correctly, dockerinit is used, because in golang code we should make
os.exec() immediately after os.clone().

If you want to play with this code, you can clone
https://github.com/avagin/libcontainer/commits/devel-new

Cc: Michael Crosby <michael@docker.com>
Cc: Victor Marmol <vmarmol@google.com>
Cc: Pavel Emelyanov <xemul@parallels.com>