### PR TITLE
Do not check if SELinux is enabled on lowlevel calls to set processlabel

### DIFF
--- a/label/label_selinux.go
+++ b/label/label_selinux.go
@@ -67,20 +67,17 @@ func FormatMountLabel(src, mountLabel string) string {
 // SetProcessLabel takes a process label and tells the kernel to assign the
 // label to the next program executed by the current process.
 func SetProcessLabel(processLabel string) error {
-	if selinux.SelinuxEnabled() {
-		return selinux.Setexeccon(processLabel)
+	if processLabel == "" {
+		return nil
 	}
-	return nil
+	return selinux.Setexeccon(processLabel)
 }
 
 // GetProcessLabel returns the process label that the kernel will assign
 // to the next program executed by the current process.  If "" is returned
 // this indicates that the default labeling will happen for the process.
 func GetProcessLabel() (string, error) {
-	if selinux.SelinuxEnabled() {
-		return selinux.Getexeccon()
-	}
-	return "", nil
+	return selinux.Getexeccon()
 }
 
 // SetFileLabel modifies the "path" label to the specified file label
@@ -110,9 +107,6 @@ func Relabel(path string, fileLabel string, relabel string) error {
 
 // GetPidLabel will return the label of the process running with the specified pid
 func GetPidLabel(pid int) (string, error) {
-	if !selinux.SelinuxEnabled() {
-		return "", nil
-	}
 	return selinux.Getpidcon(pid)
 }
 

--- a/selinux/selinux.go
+++ b/selinux/selinux.go
@@ -173,13 +173,10 @@ func Getpidcon(pid int) (string, error) {
 }
 
 func Getexeccon() (string, error) {
-	return readCon("/proc/self/attr/exec")
+	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/exec", syscall.Gettid()))
 }
 
 func writeCon(name string, val string) error {
-	if !SelinuxEnabled() {
-		return nil
-	}
 	out, err := os.OpenFile(name, os.O_WRONLY, 0)
 	if err != nil {
 		return err
@@ -388,9 +385,6 @@ func SecurityCheckContext(val string) error {
 }
 
 func CopyLevel(src, dest string) (string, error) {
-	if !SelinuxEnabled() {
-		return "", nil
-	}
 	if src == "" {
 		return "", nil
 	}
@@ -424,7 +418,7 @@ func badPrefix(fpath string) error {
 // If the fpath is a directory and recurse is true Chcon will walk the
 // directory tree setting the label
 func Chcon(fpath string, scon string, recurse bool) error {
-	if !SelinuxEnabled() {
+	if scon == "" {
 		return nil
 	}
 	if err := badPrefix(fpath); err != nil {


### PR DESCRIPTION
docker exec changes the mount namespace which fools selinux bindings
into thinking SELinux is disabled.  Bindings should just check if
a label is passed in and attempt to use it.  Docker will not call these
functions with a label if SELinux is disabled.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
