### PR TITLE
Set apparmor profile in execin

### DIFF
--- a/namespaces/execin.go
+++ b/namespaces/execin.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 
 	"github.com/docker/libcontainer"
+	"github.com/docker/libcontainer/apparmor"
 	"github.com/docker/libcontainer/cgroups"
 	"github.com/docker/libcontainer/label"
 	"github.com/docker/libcontainer/syncpipe"
@@ -94,6 +95,10 @@ func FinalizeSetns(container *libcontainer.Config, args []string) error {
 
 	if err := FinalizeNamespace(container); err != nil {
 		return err
+	}
+
+	if err := apparmor.ApplyProfile(container.AppArmorProfile); err != nil {
+		return fmt.Errorf("set apparmor profile %s: %s", container.AppArmorProfile, err)
 	}
 
 	if container.ProcessLabel != "" {


### PR DESCRIPTION
The set of the apparmor profile for the setns codepath was missing.
Selinux was being called but apparmor was forgotten.  This was causing
no profiles to be applied to the extra process spawn inside an existing
container.

A way to reproduce is to use docker with this patch applied and:

Use an apparmor enabled system!

``` bash
docker run -ti debian:jessie bash
ps auxZ
# look at the labels 

# in another shell
docker exec <name> sleep 1000

# go back to the first container and 
ps auxZ
# make sure all processes have the correct docker-default profile
```

Signed-off-by: Michael Crosby crosbymichael@gmail.com
