### PR TITLE
Fix RtAttr.Len for case with children

### DIFF
--- a/netlink/netlink_linux.go
+++ b/netlink/netlink_linux.go
@@ -205,7 +205,7 @@ func (a *RtAttr) Len() int {
 
 	l := 0
 	for _, child := range a.children {
-		l += child.Len()
+		l += rtaAlignOf(child.Len())
 	}
 	l += syscall.SizeofRtAttr
 	return rtaAlignOf(l + len(a.Data))

--- a/netlink/netlink_linux.go
+++ b/netlink/netlink_linux.go
@@ -200,7 +200,7 @@ func newRtAttrChild(parent *RtAttr, attrType int, data []byte) *RtAttr {
 
 func (a *RtAttr) Len() int {
 	if len(a.children) == 0 {
-		return (syscall.SizeofRtAttr + len(a.Data))
+		return rtaAlignOf(syscall.SizeofRtAttr + len(a.Data))
 	}
 
 	l := 0


### PR DESCRIPTION
In RtAttr.ToWireFormat, the children are written with the length aligned with
rtaAlignOf.  The length calculated in RtAttr.Len should reflect this,
otherwise the slice allocated in RtAttr.ToWireFormat is too small.