### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+### https://raw.github.com/github/gitignore/master/Go.gitignore
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+### Libcontainer
+
+# Vendored libraries
+vendor
+
+# Container.json created by IT
+integration/container.json


### PR DESCRIPTION
When building libcontainer natively I noticed some stray files appearing in my repo.
This patch ignores these files:
- Vendored libraries
- Artifacts (specifically container.json) created by the integration tests

Signed-off-by: Dave Tucker dave@dtucker.co.uk
