### PR TITLE
Add ContainerInfo instead of using a readonly state

### DIFF
--- a/container.go
+++ b/container.go
@@ -3,12 +3,7 @@ NOTE: The API is in flux and mainly not implemented. Proceed with caution until 
 */
 package libcontainer
 
-// A libcontainer container object.
-//
-// Each container is thread-safe within the same process. Since a container can
-// be destroyed by a separate process, any function may return that the container
-// was not found.
-type Container interface {
+type ContainerInfo interface {
 	// Returns the ID of the container
 	ID() string
 
@@ -21,6 +16,32 @@ type Container interface {
 
 	// Returns the current config of the container.
 	Config() *Config
+
+	// Returns the PIDs inside this container. The PIDs are in the namespace of the calling process.
+	//
+	// Errors:
+	// ContainerDestroyed - Container no longer exists,
+	// SystemError - System error.
+	//
+	// Some of the returned PIDs may no longer refer to processes in the Container, unless
+	// the Container state is PAUSED in which case every PID in the slice is valid.
+	Processes() ([]int, Error)
+
+	// Returns statistics for the container.
+	//
+	// Errors:
+	// ContainerDestroyed - Container no longer exists,
+	// SystemError - System error.
+	Stats() (*ContainerStats, Error)
+}
+
+// A libcontainer container object.
+//
+// Each container is thread-safe within the same process. Since a container can
+// be destroyed by a separate process, any function may return that the container
+// was not found.
+type Container interface {
+	ContainerInfo
 
 	// Start a process inside the container. Returns the PID of the new process (in the caller process's namespace) and a channel that will return the exit status of the process whenever it dies.
 	//
@@ -39,23 +60,6 @@ type Container interface {
 	// Errors:
 	// SystemError - System error.
 	Destroy() Error
-
-	// Returns the PIDs inside this container. The PIDs are in the namespace of the calling process.
-	//
-	// Errors:
-	// ContainerDestroyed - Container no longer exists,
-	// SystemError - System error.
-	//
-	// Some of the returned PIDs may no longer refer to processes in the Container, unless
-	// the Container state is PAUSED in which case every PID in the slice is valid.
-	Processes() ([]int, Error)
-
-	// Returns statistics for the container.
-	//
-	// Errors:
-	// ContainerDestroyed - Container no longer exists,
-	// SystemError - System error.
-	Stats() (*ContainerStats, Error)
 
 	// If the Container state is RUNNING or PAUSING, sets the Container state to PAUSING and pauses
 	// the execution of any user processes. Asynchronously, when the container finished being paused the

--- a/factory.go
+++ b/factory.go
@@ -1,7 +1,6 @@
 package libcontainer
 
 type Factory interface {
-
 	// Creates a new container with the given id and starts the initial process inside it.
 	// id must be a string containing only letters, digits and underscores and must contain
 	// between 1 and 1024 characters, inclusive.
@@ -20,13 +19,12 @@ type Factory interface {
 	// On error, any partially created container parts are cleaned up (the operation is atomic).
 	Create(id string, config *Config) (Container, Error)
 
-	// Load takes an ID for an existing container and reconstructs the container
-	// from the state.
+	// Load takes an ID for an existing container and returns the container information
+	// from the state.  This presents a read only view of the container.
 	//
 	// Errors:
 	// Path does not exist
 	// Container is stopped
 	// System error
-	// TODO: fix description
-	Load(id string) (Container, Error)
+	Load(id string) (ContainerInfo, Error)
 }


### PR DESCRIPTION
This modifies Load in the factory to return a ContainerInfo interface
that is the read only view of the container when it is loaded.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
