### PR TITLE
devices: filter /dev/console out of the node list

### DIFF
--- a/devices/devices.go
+++ b/devices/devices.go
@@ -100,7 +100,8 @@ func getDeviceNodes(path string) ([]*Device, error) {
 
 	out := []*Device{}
 	for _, f := range files {
-		if f.IsDir() {
+		switch {
+		case f.IsDir():
 			switch f.Name() {
 			case "pts", "shm", "fd":
 				continue
@@ -113,21 +114,18 @@ func getDeviceNodes(path string) ([]*Device, error) {
 				out = append(out, sub...)
 				continue
 			}
+		case f.Name() == "console":
+			continue
 		}
 
-		switch f.Name() {
-		case "console":
-			continue
-		default:
-			device, err := GetDevice(filepath.Join(path, f.Name()), "rwm")
-			if err != nil {
-				if err == ErrNotADeviceNode {
-					continue
-				}
-				return nil, err
+		device, err := GetDevice(filepath.Join(path, f.Name()), "rwm")
+		if err != nil {
+			if err == ErrNotADeviceNode {
+				continue
 			}
-			out = append(out, device)
+			return nil, err
 		}
+		out = append(out, device)
 	}
 
 	return out, nil


### PR DESCRIPTION
Fixed getDeviceNodes() so it won't add /dev/console to the device node
list.

This fixes an issue where containers wouldn't start if
/dev/console is a pts (which is the case when running docker inside
docker), because devpts inodes are special and cannot be created with
mknod: attempting to open the result of doing so will return EIO.

Since later libcontainer would attempt to open the file to mount --bind
over it and fail because of the EIO error, the container wouldn't start
if the /dev/console was a pts, which is the case inside a docker
that was started from a pts.

getDeviceNodes() already filters pts so this change is consistent
with the current behavior.

Signed-off-by: Alejandro Ojeda alex@x3y.org
## 

This patch fixes the following issue in dind: https://github.com/jpetazzo/dind/issues/25
