### PR TITLE
Add new interfaces for label/selinux

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -43,3 +43,15 @@ func ReserveLabel(label string) error {
 func UnreserveLabel(label string) error {
 	return nil
 }
+
+// DupSecOpt takes an process label and returns security options that
+// can be used to set duplicate labels on future container processes
+func DupSecOpt(src string) []string {
+	return nil
+}
+
+// DisableSecOpt returns a security opt that can disable labeling
+// support for future container processes
+func DisableSecOpt() []string {
+	return nil
+}

--- a/label/label_selinux.go
+++ b/label/label_selinux.go
@@ -17,7 +17,6 @@ func InitLabels(options []string) (string, string, error) {
 	if !selinux.SelinuxEnabled() {
 		return "", "", nil
 	}
-	var err error
 	processLabel, mountLabel := selinux.GetLxcContexts()
 	if processLabel != "" {
 		pcon := selinux.NewContext(processLabel)
@@ -38,7 +37,7 @@ func InitLabels(options []string) (string, string, error) {
 		processLabel = pcon.Get()
 		mountLabel = mcon.Get()
 	}
-	return processLabel, mountLabel, err
+	return processLabel, mountLabel, nil
 }
 
 // DEPRECATED: The GenLabels function is only to be used during the transition to the official API.
@@ -129,4 +128,16 @@ func ReserveLabel(label string) error {
 func UnreserveLabel(label string) error {
 	selinux.FreeLxcContexts(label)
 	return nil
+}
+
+// DupSecOpt takes an process label and returns security options that
+// can be used to set duplicate labels on future container processes
+func DupSecOpt(src string) []string {
+	return selinux.DupSecOpt(src)
+}
+
+// DisableSecOpt returns a security opt that can disable labeling
+// support for future container processes
+func DisableSecOpt() []string {
+	return selinux.DisableSecOpt()
 }

--- a/label/label_selinux_test.go
+++ b/label/label_selinux_test.go
@@ -3,6 +3,7 @@
 package label
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/docker/libcontainer/selinux"
@@ -33,7 +34,7 @@ func TestInit(t *testing.T) {
 			t.Fatal(err)
 		}
 		if plabel != "user_u:user_r:user_t:s0:c1,c15" || mlabel != "user_u:object_r:svirt_sandbox_file_t:s0:c1,c15" {
-			t.Log("InitLabels User Failed")
+			t.Log("InitLabels User Match Failed")
 			t.Log(plabel, mlabel)
 			t.Fatal(err)
 		}
@@ -44,5 +45,45 @@ func TestInit(t *testing.T) {
 			t.Log("InitLabels Bad Failed")
 			t.Fatal(err)
 		}
+	}
+}
+func TestDuplicateLabel(t *testing.T) {
+	secopt := DupSecOpt("system_u:system_r:svirt_lxc_net_t:s0:c1,c2")
+	t.Log(secopt)
+	for _, opt := range secopt {
+		con := strings.SplitN(opt, ":", 3)
+		if len(con) != 3 || con[0] != "label" {
+			t.Errorf("Invalid DupSecOpt return value")
+			continue
+		}
+		if con[1] == "user" {
+			if con[2] != "system_u" {
+				t.Errorf("DupSecOpt Failed user incorrect")
+			}
+			continue
+		}
+		if con[1] == "role" {
+			if con[2] != "system_r" {
+				t.Errorf("DupSecOpt Failed role incorrect")
+			}
+			continue
+		}
+		if con[1] == "type" {
+			if con[2] != "svirt_lxc_net_t" {
+				t.Errorf("DupSecOpt Failed type incorrect")
+			}
+			continue
+		}
+		if con[1] == "level" {
+			if con[2] != "s0:c1,c2" {
+				t.Errorf("DupSecOpt Failed level incorrect")
+			}
+			continue
+		}
+		t.Errorf("DupSecOpt Failed invalid field %q", con[1])
+	}
+	secopt = DisableSecOpt()
+	if secopt[0] != "label:disable" {
+		t.Errorf("DisableSecOpt Failed level incorrect")
 	}
 }

--- a/selinux/selinux.go
+++ b/selinux/selinux.go
@@ -434,3 +434,28 @@ func Chcon(fpath string, scon string, recurse bool) error {
 
 	return Setfilecon(fpath, scon)
 }
+
+// DupSecOpt takes an SELinux process label and returns security options that
+// can will set the SELinux Type and Level for future container processes
+func DupSecOpt(src string) []string {
+	if src == "" {
+		return nil
+	}
+	con := NewContext(src)
+	if con["user"] == "" ||
+		con["role"] == "" ||
+		con["type"] == "" ||
+		con["level"] == "" {
+		return nil
+	}
+	return []string{"label:user:" + con["user"],
+		"label:role:" + con["role"],
+		"label:type:" + con["type"],
+		"label:level:" + con["level"]}
+}
+
+// DisableSecOpt returns a security opt that can be used to disabling SELinux
+// labeling support for future container processes
+func DisableSecOpt() []string {
+	return []string{"label:disable"}
+}


### PR DESCRIPTION
We need the ability when using --ipc container:ID to match the SELinux label of the
container that the new container is sharing a label with.

Also add the ability to get the option to disable SELinux labeling for a container.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
