### PR TITLE
use system.Set{u,g}id to fix Set{u,g}id on Go 1.4

### DIFF
--- a/namespaces/init.go
+++ b/namespaces/init.go
@@ -164,11 +164,11 @@ func SetupUser(u string) error {
 		return fmt.Errorf("setgroups %s", err)
 	}
 
-	if err := syscall.Setgid(gid); err != nil {
+	if err := system.Setgid(gid); err != nil {
 		return fmt.Errorf("setgid %s", err)
 	}
 
-	if err := syscall.Setuid(uid); err != nil {
+	if err := system.Setuid(uid); err != nil {
 		return fmt.Errorf("setuid %s", err)
 	}
 


### PR DESCRIPTION
This fixes errors like this one with Go tip (future 1.4) and Go 1.4b1:

```
runtime_test.go:604: finalize namespace setup user setgid operation not supported
```
