### PR TITLE
libcontainer: setup cpuset cgroup by default

### DIFF
--- a/cgroups/fs/cpuset.go
+++ b/cgroups/fs/cpuset.go
@@ -46,8 +46,12 @@ func (s *CpusetGroup) SetDir(dir, value string, pid int) error {
 		return err
 	}
 
-	if err := writeFile(dir, "cpuset.cpus", value); err != nil {
-		return err
+	// If we don't use --cpuset, the default cpuset.cpus is set in
+	// s.ensureParent, otherwise, use the value we set
+	if value != "" {
+		if err := writeFile(dir, "cpuset.cpus", value); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -147,16 +147,14 @@ func Apply(c *cgroups.Cgroup, pid int) (cgroups.ActiveCgroup, error) {
 
 	}
 
-	// we need to manually join the freezer cgroup in systemd because it does not currently support it
-	// via the dbus api
+	// we need to manually join the freezer and cpuset cgroup in systemd
+	// because it does not currently support it via the dbus api.
 	if err := joinFreezer(c, pid); err != nil {
 		return nil, err
 	}
 
-	if c.CpusetCpus != "" {
-		if err := joinCpuset(c, pid); err != nil {
-			return nil, err
-		}
+	if err := joinCpuset(c, pid); err != nil {
+		return nil, err
 	}
 
 	return res, nil


### PR DESCRIPTION
Currently if we don't use --cpuset, the cpuset cgroup is not
created, it's bad if we want to modify cpuset config subsequently,
change the behavior to make it right.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
