### PR TITLE
Updated cover tool import path.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM crosbymichael/golang
 
 RUN apt-get update && apt-get install -y gcc make
-RUN go get code.google.com/p/go.tools/cmd/cover
+RUN go get golang.org/x/tools/cmd/cover
 
 ENV GOPATH $GOPATH:/go/src/github.com/docker/libcontainer/vendor
 RUN go get github.com/docker/docker/pkg/term


### PR DESCRIPTION
Noticed that the Go tools repository has been moved: https://groups.google.com/d/msg/golang-nuts/eD8dh3T9yyA/l5Ail-xfMiAJ
