### PR TITLE
Set correct env variables for `docker exec` commands

### DIFF
--- a/namespaces/execin.go
+++ b/namespaces/execin.go
@@ -111,7 +111,7 @@ func FinalizeSetns(container *libcontainer.Config, args []string) error {
 		}
 	}
 
-	if err := system.Execv(args[0], args[0:], container.Env); err != nil {
+	if err := system.Execv(args[0], args[0:], os.Environ()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
I made a test case for this in https://github.com/docker/docker/pull/9174

because `LoadContainerEnvironment` is already run, os.Environ() will return the
correct environment variables for the exec command (i.e. removed duplicated
envs, set HOME for user etc...)

Docker-DCO-1.1-Signed-off-by: Daniel, Dao Quang Minh dqminh89@gmail.com (github: dqminh)
