### PR TITLE
Provide better sethostname error message

### DIFF
--- a/namespaces/init.go
+++ b/namespaces/init.go
@@ -100,7 +100,7 @@ func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, pip
 
 	if container.Hostname != "" {
 		if err := syscall.Sethostname([]byte(container.Hostname)); err != nil {
-			return fmt.Errorf("sethostname %s", err)
+			return fmt.Errorf("unable to sethostname %q: %s", container.Hostname, err)
 		}
 	}
 


### PR DESCRIPTION
This tries to add a marginally better error message including the hostname when the syscall fails. 

Signed-off-by: Michael Crosby crosbymichael@gmail.com
