### PR TITLE
Set child sub reaper option on nsenter 

### DIFF
--- a/namespaces/nsenter/nsenter.c
+++ b/namespaces/nsenter/nsenter.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/prctl.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <getopt.h>
@@ -87,6 +88,11 @@ void nsenter()
 	if (strncmp(argv[0], kNsEnter, strlen(kNsEnter)) != 0) {
 		return;
 	}
+
+	if (prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) == -1) {
+                fprintf(stderr, "nsenter: failed to set child subreaper: %s", strerror(errno));
+                exit(1);
+        }
 
 	static const struct option longopts[] = {
 		{"nspid", required_argument, NULL, 'n'},


### PR DESCRIPTION
This will help cleanup all processes orphaned by ExecIn.

Docker-DCO-1.1-Signed-off-by: Vishnu Kannan vishnuk@google.com (github: vishh)
