### PR TITLE
Remove hairpin nat on veth create

### DIFF
--- a/network/veth.go
+++ b/network/veth.go
@@ -39,9 +39,6 @@ func (v *Veth) Create(n *Network, nspid int, networkState *NetworkState) error {
 	if err := SetMtu(name1, n.Mtu); err != nil {
 		return err
 	}
-	if err := SetHairpinMode(name1, true); err != nil {
-		return err
-	}
 	if err := InterfaceUp(name1); err != nil {
 		return err
 	}


### PR DESCRIPTION
Writing to this file within /sys is casuing some issues for
older kernels, specifically with 2.6.xx, where the write is failing
because /sys is becoming ro.  We will continue to work on the 2.6 issues
but for the time being we cannot ship this with it enabled as it's
breaking all container runs.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
