### PR TITLE
Add call to label to allow it to tell kernel how to label created files

### DIFF
--- a/label/label.go
+++ b/label/label.go
@@ -25,6 +25,10 @@ func SetFileLabel(path string, fileLabel string) error {
 	return nil
 }
 
+func SetFileCreateLabel(fileLabel string) error {
+	return nil
+}
+
 func Relabel(path string, fileLabel string, relabel string) error {
 	return nil
 }

--- a/label/label_selinux.go
+++ b/label/label_selinux.go
@@ -87,6 +87,14 @@ func SetFileLabel(path string, fileLabel string) error {
 	return nil
 }
 
+// Tell the kernel the label for all files to be created
+func SetFileCreateLabel(fileLabel string) error {
+	if selinux.SelinuxEnabled() {
+		return selinux.Setfscreatecon(fileLabel)
+	}
+	return nil
+}
+
 // Change the label of path to the filelabel string.  If the relabel string
 // is "z", relabel will change the MCS label to s0.  This will allow all
 // containers to share the content.  If the relabel string is a "Z" then


### PR DESCRIPTION
SELinux supports a call that tells the kernel, from this point onward
create content with this label.  If you pass "", the kernel will
go back to the default.

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
