### PR TITLE
netlink: add NetworkSetTxQueueLen to set qlen

### DIFF
--- a/netlink/netlink_unsupported.go
+++ b/netlink/netlink_unsupported.go
@@ -47,6 +47,10 @@ func NetworkSetMTU(iface *net.Interface, mtu int) error {
 	return ErrNotImplemented
 }
 
+func NetworkSetTxQueueLen(iface *net.Interface, txQueueLen int) error {
+	return ErrNotImplemented
+}
+
 func NetworkCreateVethPair(name1, name2 string, txQueueLen int) error {
 	return ErrNotImplemented
 }


### PR DESCRIPTION
This PR adds a new function which can be used to set the queue length of an interface.
