### PR TITLE
Add support for ppc64, ppc64le, s390x

### DIFF
--- a/system/setns_linux.go
+++ b/system/setns_linux.go
@@ -11,9 +11,12 @@ import (
 // We need different setns values for the different platforms and arch
 // We are declaring the macro here because the SETNS syscall does not exist in th stdlib
 var setNsMap = map[string]uintptr{
-	"linux/386":   346,
-	"linux/amd64": 308,
-	"linux/arm":   374,
+	"linux/386":     346,
+	"linux/amd64":   308,
+	"linux/arm":     374,
+	"linux/ppc64":   350,
+	"linux/ppc64le": 350,
+	"linux/s390x":   339,
 }
 
 func Setns(fd uintptr, flags uintptr) error {

--- a/system/syscall_linux_64.go
+++ b/system/syscall_linux_64.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux,amd64 linux,ppc64 linux,ppc64le linux,s390x
 
 package system
 


### PR DESCRIPTION
This PR adds support for Power systems (ppc64, ppc64le), and System z (s390x).

We have successful built and run Docker on ppc64, ppc64le, s390x using this patch.

Signed-off-by: Yohei Ueda yohei@jp.ibm.com
