### PR TITLE
Allow users to share pid ns with host or other containers

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,6 +50,9 @@ type Config struct {
 	// Ipc specifies the container's ipc setup to be created
 	IpcNsPath string `json:"ipc,omitempty"`
 
+	// PidNS specifies the container's pid setup to be created
+	PidNsPath string `json:"pidns,omitempty"`
+
 	// Routes can be specified to create entries in the route table as the container is started
 	Routes []*Route `json:"routes,omitempty"`
 

--- a/namespaces/init.go
+++ b/namespaces/init.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/libcontainer/mount"
 	"github.com/docker/libcontainer/netlink"
 	"github.com/docker/libcontainer/network"
+	"github.com/docker/libcontainer/pidns"
 	"github.com/docker/libcontainer/security/capabilities"
 	"github.com/docker/libcontainer/security/restrict"
 	"github.com/docker/libcontainer/system"
@@ -81,6 +82,9 @@ func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, pip
 	}
 	if err := ipc.Initialize(container.IpcNsPath); err != nil {
 		return fmt.Errorf("setup IPC %s", err)
+	}
+	if err := pidns.Initialize(container.PidNsPath); err != nil {
+		return fmt.Errorf("setup PIDNS %s", err)
 	}
 	if err := setupNetwork(container, networkState); err != nil {
 		return fmt.Errorf("setup networking %s", err)

--- a/pidns/pidns.go
+++ b/pidns/pidns.go
@@ -1,0 +1,29 @@
+package pidns
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/docker/libcontainer/system"
+)
+
+// Join the PID Namespace of specified pid path if it exists.
+// If the path does not exist then you are not joining a container.
+func Initialize(nsPath string) error {
+	if nsPath == "" {
+		return nil
+	}
+	f, err := os.OpenFile(nsPath, os.O_RDONLY, 0)
+	if err != nil {
+		return fmt.Errorf("failed get PID namespace fd: %v", err)
+	}
+
+	err = system.Setns(f.Fd(), syscall.CLONE_NEWPID)
+	f.Close()
+
+	if err != nil {
+		return fmt.Errorf("failed to setns current PID namespace: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
This patch allows us to turn off the PID namespace and to
use another containers pid namespace

Docker-DCO-1.1-Signed-off-by: Dan Walsh dwalsh@redhat.com (github: rhatdan)
