### PR TITLE
user: MAINTAINERS: add cyphar (myself) as a maintainer

### DIFF
--- a/user/MAINTAINERS
+++ b/user/MAINTAINERS
@@ -1,1 +1,2 @@
 Tianon Gravi <admwiggin@gmail.com> (@tianon)
+Aleksa Sarai <cyphar@cyphar.com> (@cyphar)


### PR DESCRIPTION
This patch adds Aleksa Sarai to the maintainer list for libcontainer's
user API. The reason for this being that I have written a substantial
portion of the current API.

Signed-off-by: Aleksa Sarai cyphar@cyphar.com (github: cyphar)
