### PR TITLE
define PR_SET_CHILD_SUBREAPER if not set

### DIFF
--- a/namespaces/nsenter/nsenter.c
+++ b/namespaces/nsenter/nsenter.c
@@ -15,6 +15,10 @@
 #include <unistd.h>
 #include <getopt.h>
 
+#ifndef PR_SET_CHILD_SUBREAPER
+#define PR_SET_CHILD_SUBREAPER 36
+#endif
+
 static const kBufSize = 256;
 static const char *kNsEnter = "nsenter";
 


### PR DESCRIPTION
Do an explicit define of `PR_SET_CHILD_SUBREAPER` for system with older headers.

~~Currently, setting subreaper option will fail in rhel/centos 6.5/6.6, which causes `docker exec` to fail
https://botbot.me/freenode/docker-dev/2014-12-13/?msg=27459979&page=2 . This patch ignores errors casued by setting subreaper option.~~
