### PR TITLE
Exec process should have its own cgroup

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -119,6 +119,10 @@ func Kill(c *cgroups.Cgroup, signal syscall.Signal) error {
 
 	pids, err := GetPids(c)
 	if err != nil {
+		// if the cgroup does not exist, then it's stopped
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 
@@ -142,6 +146,10 @@ func waitStop(c *cgroups.Cgroup, initialWait time.Duration, tries int) error {
 		}
 		pids, err := GetPids(c)
 		if err != nil {
+			// if the cgroup does not exist, then it's stopped
+			if os.IsNotExist(err) {
+				return nil
+			}
 			return err
 		}
 		// all tasks in the current cgroup have been removed

--- a/cgroups/systemd/apply_nosystemd.go
+++ b/cgroups/systemd/apply_nosystemd.go
@@ -4,6 +4,7 @@ package systemd
 
 import (
 	"fmt"
+	"syscall"
 
 	"github.com/docker/libcontainer/cgroups"
 )
@@ -14,6 +15,14 @@ func UseSystemd() bool {
 
 func Apply(c *cgroups.Cgroup, pid int) (map[string]string, error) {
 	return nil, fmt.Errorf("Systemd not supported")
+}
+
+func Stop(c *cgroups.Cgroup) error {
+	return fmt.Errorf("Systemd not supported")
+}
+
+func Kill(c *cgroups.Cgroup, signal syscall.Signal) error {
+	return fmt.Errorf("Systemd not supported")
 }
 
 func GetPids(c *cgroups.Cgroup) ([]int, error) {

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	systemd "github.com/coreos/go-systemd/dbus"
@@ -169,6 +170,20 @@ func Apply(c *cgroups.Cgroup, pid int) (map[string]string, error) {
 		paths[sysname] = subsystemPath
 	}
 	return paths, nil
+}
+
+// Stop stops the current cgroup unit
+func Stop(c *cgroups.Cgroup) error {
+	unitName := getUnitName(c)
+	_, err := theConn.StopUnit(unitName, "replace")
+	return err
+}
+
+// Kill sends the signal to all processes the current cgroup unit
+func Kill(c *cgroups.Cgroup, signal syscall.Signal) error {
+	unitName := getUnitName(c)
+	theConn.KillUnit(unitName, int32(signal))
+	return nil
 }
 
 func writeFile(dir, file, data string) error {

--- a/config.go
+++ b/config.go
@@ -126,6 +126,24 @@ type Config struct {
 	AdditionalGroups []int `json:"additional_groups,omitempty"`
 }
 
+// ExecConfig defines configuration options for executing a process inside a
+// running container
+//
+// TODO:
+// - add User to customize the uid/gid of the executing process
+type ExecConfig struct {
+	// configurations of the container
+	Container *Config `json:"container"`
+
+	// current state of the container
+	State *State `json:"state"`
+
+	// Cgroups specify specific settings for the subsystems that the exec'ed
+	// process is placed into. The process's cgroups will always be nested
+	// inside the container's cgroups
+	Cgroups *cgroups.Cgroup `json:"cgroups,omitempty"`
+}
+
 // Routes can be specified to create entries in the route table as the container is started
 //
 // All of destination, source, and gateway should be either IPv4 or IPv6.

--- a/namespaces/exec.go
+++ b/namespaces/exec.go
@@ -193,12 +193,15 @@ func DefaultCreateCommand(container *libcontainer.Config, console, dataPath, ini
 // SetupCgroups applies the cgroup restrictions to the process running in the container based
 // on the container's configuration
 func SetupCgroups(container *libcontainer.Config, nspid int) (map[string]string, error) {
-	if container.Cgroups != nil {
-		c := container.Cgroups
+	return setupCgroups(container.Cgroups, nspid)
+}
+
+func setupCgroups(c *cgroups.Cgroup, pid int) (map[string]string, error) {
+	if c != nil {
 		if systemd.UseSystemd() {
-			return systemd.Apply(c, nspid)
+			return systemd.Apply(c, pid)
 		}
-		return fs.Apply(c, nspid)
+		return fs.Apply(c, pid)
 	}
 	return map[string]string{}, nil
 }

--- a/namespaces/execin.go
+++ b/namespaces/execin.go
@@ -151,7 +151,7 @@ func EnterCgroups(state *libcontainer.State, pid int) error {
 	return cgroups.EnterPid(state.CgroupPaths, pid)
 }
 
-// cleanup remaining tasks in the cgroup and then remove the cgroups
+// cleanupCgroups stops remaining tasks in the cgroup and then remove the cgroups
 func cleanupCgroups(c *cgroups.Cgroup, paths map[string]string) error {
 	if c != nil {
 		if systemd.UseSystemd() {

--- a/namespaces/execin.go
+++ b/namespaces/execin.go
@@ -82,6 +82,9 @@ func ExecIn(config *libcontainer.ExecConfig, userArgs []string, initPath, action
 		}
 	} else {
 		config.Cgroups.Parent = filepath.Join(container.Cgroups.Parent, container.Cgroups.Name)
+		// get devices settings from the container
+		config.Cgroups.AllowedDevices = container.Cgroups.AllowedDevices
+		config.Cgroups.AllowAllDevices = container.Cgroups.AllowAllDevices
 
 		cgroupPaths, err := setupCgroups(config.Cgroups, cmd.Process.Pid)
 		if err != nil {

--- a/nsinit/exec.go
+++ b/nsinit/exec.go
@@ -120,7 +120,11 @@ func startInExistingContainer(config *libcontainer.Config, state *libcontainer.S
 		}()
 	}
 
-	return namespaces.ExecIn(config, state, context.Args(), os.Args[0], action, stdin, stdout, stderr, console, startCallback)
+	execConfig := &libcontainer.ExecConfig{
+		Container: config,
+		State:     state,
+	}
+	return namespaces.ExecIn(execConfig, context.Args(), os.Args[0], action, stdin, stdout, stderr, console, startCallback)
 }
 
 // startContainer starts the container. Returns the exit status or -1 and an


### PR DESCRIPTION
### How it works,

ExecIn now requires the user to pass in a config, which contains the container config and also an optional cgroup config. If the cgroup config exists, then it will create a subcgroup under the original container's cgroup and use it to process tracking. When the main exec process exits, all other processes inside the subcgroup will be stopped/killed and the subcgroup will be removed

- [x] create sub-cgroups for each execin process
- [x] track and remove orphan process after the execin process finishes
- [x] cleanup sub-cgroups after the execin process finishes