### PR TITLE
make RestrictSys entries configurable

### DIFF
--- a/config.go
+++ b/config.go
@@ -69,9 +69,13 @@ type Config struct {
 	// commonly used by selinux
 	ProcessLabel string `json:"process_label,omitempty"`
 
-	// RestrictSys will remount /proc/sys, /sys, and mask over sysrq-trigger as well as /proc/irq and
-	// /proc/bus
+	// RestrictSys will remount and mask entries defined in RestrictedSysEntries.
+	// If this is true and RestrictedSysEntries is empty, the default RestrictedSysEntries will be used.
 	RestrictSys bool `json:"restrict_sys,omitempty"`
+
+	// RestrictedSysEntries can be used to remount and mask entries from /proc
+	// It'll remount and mask proc/sys, proc/sysrq-trigger, proc/irq and proc/bus if left empty.
+	RestrictedSysEntries []string `json:"restricted_sys_entries,omitempty"`
 
 	// Rlimits specifies the resource limits, such as max open files, to set in the container
 	// If Rlimits are not set, the container will inherit rlimits from the parent process

--- a/namespaces/init.go
+++ b/namespaces/init.go
@@ -116,10 +116,15 @@ func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, pip
 		return fmt.Errorf("set process label %s", err)
 	}
 
-	// TODO: (crosbymichael) make this configurable at the Config level
 	if container.RestrictSys {
-		if err := restrict.Restrict("proc/sys", "proc/sysrq-trigger", "proc/irq", "proc/bus"); err != nil {
-			return err
+		if len(container.RestrictedSysEntries) == 0 {
+			if err := restrict.Restrict("proc/sys", "proc/sysrq-trigger", "proc/irq", "proc/bus"); err != nil {
+				return err
+			}
+		} else {
+			if err := restrict.Restrict(container.RestrictedSysEntries...); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR addresses the TODO from `namespaces/init.go` which was added there by crosbymichael. 