### PR TITLE
OOM Notify refactoring

### DIFF
--- a/notify_linux.go
+++ b/notify_linux.go
@@ -1,33 +1,29 @@
 // +build linux
 
-package fs
+package libcontainer
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
-
-	"github.com/docker/libcontainer/cgroups"
 )
 
-// NotifyOnOOM sends signals on the returned channel when the cgroup reaches
-// its memory limit. The channel is closed when the cgroup is removed.
-func NotifyOnOOM(c *cgroups.Cgroup) (<-chan struct{}, error) {
-	d, err := getCgroupData(c, 0)
+const oomCgroupName = "memory"
+
+// NotifyOnOOM returns channel on which you can expect event about OOM,
+// if process died without OOM this channel will be closed.
+// s is current *libcontainer.State for container.
+func NotifyOnOOM(s *State) (<-chan struct{}, error) {
+	dir := s.CgroupPaths[oomCgroupName]
+	if dir == "" {
+		return nil, fmt.Errorf("There is no path for %q in state", oomCgroupName)
+	}
+	oomControl, err := os.Open(filepath.Join(dir, "memory.oom_control"))
 	if err != nil {
 		return nil, err
 	}
-
-	return notifyOnOOM(d)
-}
-
-func notifyOnOOM(d *data) (<-chan struct{}, error) {
-	dir, err := d.path("memory")
-	if err != nil {
-		return nil, err
-	}
-
 	fd, _, syserr := syscall.RawSyscall(syscall.SYS_EVENTFD2, 0, syscall.FD_CLOEXEC, 0)
 	if syserr != 0 {
 		return nil, syserr
@@ -35,48 +31,32 @@ func notifyOnOOM(d *data) (<-chan struct{}, error) {
 
 	eventfd := os.NewFile(fd, "eventfd")
 
-	oomControl, err := os.Open(filepath.Join(dir, "memory.oom_control"))
-	if err != nil {
-		eventfd.Close()
-		return nil, err
-	}
-
-	var (
-		eventControlPath = filepath.Join(dir, "cgroup.event_control")
-		data             = fmt.Sprintf("%d %d", eventfd.Fd(), oomControl.Fd())
-	)
-
-	if err := writeFile(dir, "cgroup.event_control", data); err != nil {
+	eventControlPath := filepath.Join(dir, "cgroup.event_control")
+	data := fmt.Sprintf("%d %d", eventfd.Fd(), oomControl.Fd())
+	if err := ioutil.WriteFile(eventControlPath, []byte(data), 0700); err != nil {
 		eventfd.Close()
 		oomControl.Close()
 		return nil, err
 	}
-
 	ch := make(chan struct{})
-
 	go func() {
 		defer func() {
 			close(ch)
 			eventfd.Close()
 			oomControl.Close()
 		}()
-
 		buf := make([]byte, 8)
-
 		for {
 			if _, err := eventfd.Read(buf); err != nil {
 				return
 			}
-
 			// When a cgroup is destroyed, an event is sent to eventfd.
 			// So if the control path is gone, return instead of notifying.
 			if _, err := os.Lstat(eventControlPath); os.IsNotExist(err) {
 				return
 			}
-
 			ch <- struct{}{}
 		}
 	}()
-
 	return ch, nil
 }

--- a/notify_linux_test.go
+++ b/notify_linux_test.go
@@ -1,38 +1,48 @@
 // +build linux
 
-package fs
+package libcontainer
 
 import (
 	"encoding/binary"
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 	"time"
 )
 
 func TestNotifyOnOOM(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
-
-	helper.writeFileContents(map[string]string{
-		"memory.oom_control":   "",
-		"cgroup.event_control": "",
-	})
-
+	memoryPath, err := ioutil.TempDir("", "testnotifyoom-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oomPath := filepath.Join(memoryPath, "memory.oom_control")
+	eventPath := filepath.Join(memoryPath, "cgroup.event_control")
+	if err := ioutil.WriteFile(oomPath, []byte{}, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile(eventPath, []byte{}, 0700); err != nil {
+		t.Fatal(err)
+	}
 	var eventFd, oomControlFd int
-
-	ooms, err := notifyOnOOM(helper.CgroupData)
+	st := &State{
+		CgroupPaths: map[string]string{
+			"memory": memoryPath,
+		},
+	}
+	ooms, err := NotifyOnOOM(st)
 	if err != nil {
 		t.Fatal("expected no error, got:", err)
 	}
 
-	memoryPath, _ := helper.CgroupData.path("memory")
-	data, err := readFile(memoryPath, "cgroup.event_control")
+	data, err := ioutil.ReadFile(eventPath)
 	if err != nil {
 		t.Fatal("couldn't read event control file:", err)
 	}
 
-	if _, err := fmt.Sscanf(data, "%d %d", &eventFd, &oomControlFd); err != nil {
+	if _, err := fmt.Sscanf(string(data), "%d %d", &eventFd, &oomControlFd); err != nil {
 		t.Fatalf("invalid control data %q: %s", data, err)
 	}
 
@@ -62,7 +72,9 @@ func TestNotifyOnOOM(t *testing.T) {
 
 	// simulate what happens when a cgroup is destroyed by cleaning up and then
 	// writing to the eventfd.
-	helper.cleanup()
+	if err := os.RemoveAll(memoryPath); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := syscall.Write(efd, buf); err != nil {
 		t.Fatal("unable to write to eventfd:", err)
 	}


### PR DESCRIPTION
Now `NotifyOnOOM` is in `cgroups` package and should be used with path to `memory` cgroup, which can be obtained from container `State`
