### PR TITLE
Namespaces methods should act on pointer

### DIFF
--- a/config.go
+++ b/config.go
@@ -30,26 +30,26 @@ type Namespace struct {
 
 type Namespaces []Namespace
 
-func (n Namespaces) Remove(t NamespaceType) bool {
+func (n *Namespaces) Remove(t NamespaceType) bool {
 	i := n.index(t)
 	if i == -1 {
 		return false
 	}
-	n = append(n[:i], n[i+1:]...)
+	*n = append((*n)[:i], (*n)[i+1:]...)
 	return true
 }
 
-func (n Namespaces) Add(t NamespaceType, path string) {
+func (n *Namespaces) Add(t NamespaceType, path string) {
 	i := n.index(t)
 	if i == -1 {
-		n = append(n, Namespace{Type: t, Path: path})
+		*n = append(*n, Namespace{Type: t, Path: path})
 		return
 	}
-	n[i].Path = path
+	(*n)[i].Path = path
 }
 
-func (n Namespaces) index(t NamespaceType) int {
-	for i, ns := range n {
+func (n *Namespaces) index(t NamespaceType) int {
+	for i, ns := range *n {
 		if ns.Type == t {
 			return i
 		}
@@ -57,7 +57,7 @@ func (n Namespaces) index(t NamespaceType) int {
 	return -1
 }
 
-func (n Namespaces) Contains(t NamespaceType) bool {
+func (n *Namespaces) Contains(t NamespaceType) bool {
 	return n.index(t) != -1
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -158,3 +158,15 @@ func TestSelinuxLabels(t *testing.T) {
 		t.Fatalf("expected mount label %q but received %q", label, container.MountConfig.MountLabel)
 	}
 }
+
+func TestRemoveNamespace(t *testing.T) {
+	ns := Namespaces{
+		{Type: NEWNET},
+	}
+	if !ns.Remove(NEWNET) {
+		t.Fatal("NEWNET was not removed")
+	}
+	if len(ns) != 0 {
+		t.Fatalf("namespaces should have 0 items but reports %d", len(ns))
+	}
+}


### PR DESCRIPTION
You have to act on a pointer if you wish to modify the slice within the methods.

Signed-off-by: Michael Crosby crosbymichael@gmail.com
