### PR TITLE
Fix vet errors

### DIFF
--- a/cgroups/fs/stats_util_test.go
+++ b/cgroups/fs/stats_util_test.go
@@ -53,7 +53,7 @@ func expectBlkioStatsEquals(t *testing.T, expected, actual cgroups.BlkioStats) {
 	}
 
 	if err := blkioStatEntryEquals(expected.IoMergedRecursive, actual.IoMergedRecursive); err != nil {
-		log.Printf("blkio IoMergedRecursive do not match - %s vs %s\n", expected.IoMergedRecursive, actual.IoMergedRecursive)
+		log.Printf("blkio IoMergedRecursive do not match - %v vs %v\n", expected.IoMergedRecursive, actual.IoMergedRecursive)
 		t.Fail()
 	}
 

--- a/integration/template_test.go
+++ b/integration/template_test.go
@@ -32,13 +32,13 @@ func newTemplateConfig(rootfs string) *libcontainer.Config {
 			"KILL",
 			"AUDIT_WRITE",
 		},
-		Namespaces: libcontainer.Namespaces{
+		Namespaces: libcontainer.Namespaces([]libcontainer.Namespace{
 			{Type: libcontainer.NEWNS},
 			{Type: libcontainer.NEWUTS},
 			{Type: libcontainer.NEWIPC},
 			{Type: libcontainer.NEWPID},
 			{Type: libcontainer.NEWNET},
-		},
+		}),
 		Cgroups: &cgroups.Cgroup{
 			Parent:          "integration",
 			AllowAllDevices: false,


### PR DESCRIPTION
I calmed `vet` about `libcontainer.Namespace` because it is very suspicious about types from other packages.