### PR TITLE
Changes Dockerfile to use go 1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM crosbymichael/golang
+FROM golang:1.4
 
-RUN apt-get update && apt-get install -y gcc make
 RUN go get golang.org/x/tools/cmd/cover
 
 ENV GOPATH $GOPATH:/go/src/github.com/docker/libcontainer/vendor


### PR DESCRIPTION
Ran the tests locally using the image based off golang:1.4 and they succeeded.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com> (github: mrunalp)