### PR TITLE
namespace don't change without a proper namespace

### DIFF
--- a/namespaces/exec.go
+++ b/namespaces/exec.go
@@ -138,7 +138,7 @@ func DefaultCreateCommand(container *libcontainer.Config, console, dataPath, ini
 	if command.SysProcAttr == nil {
 		command.SysProcAttr = &syscall.SysProcAttr{}
 	}
-	command.SysProcAttr.Cloneflags = uintptr(GetNamespaceFlags(container.Namespaces))
+	command.SysProcAttr.Cloneflags = uintptr(getNamespaceFlags(container.Namespaces, true))
 
 	command.SysProcAttr.Pdeathsig = syscall.SIGKILL
 	command.ExtraFiles = []*os.File{pipe}

--- a/namespaces/init.go
+++ b/namespaces/init.go
@@ -95,11 +95,18 @@ func Init(container *libcontainer.Config, uncleanRootfs, consolePath string, pip
 
 	label.Init()
 
-	if err := mount.InitializeMountNamespace(rootfs,
-		consolePath,
-		container.RestrictSys,
-		(*mount.MountConfig)(container.MountConfig)); err != nil {
-		return fmt.Errorf("setup mount namespace %s", err)
+	cloneFlags, err := checkNamespaceFlags(container)
+	if err != nil {
+		return fmt.Errorf("checking namespaces %s", err)
+	}
+
+	if (cloneFlags & syscall.CLONE_NEWNS) != 0 {
+		if err := mount.InitializeMountNamespace(rootfs,
+			consolePath,
+			container.RestrictSys,
+			(*mount.MountConfig)(container.MountConfig)); err != nil {
+			return fmt.Errorf("setup mount namespace %s", err)
+		}
 	}
 
 	if container.Hostname != "" {


### PR DESCRIPTION
avagin report excerpt:
In a config file we specify which namespaces have to be created and which
configuration have to be applied for them. Currently if a configuration is
specified without a proper namespace, it is applied to the host namespace.

this patch is refactor from avagin's pr.
https://github.com/docker/libcontainer/pull/324

Signed-off-by: Deshi Xiao <xiaods@gmail.com>