### PR TITLE
Add nsinit command to display oom notifications

### DIFF
--- a/nsinit/main.go
+++ b/nsinit/main.go
@@ -53,11 +53,12 @@ func main() {
 	app.Before = preload
 
 	app.Commands = []cli.Command{
+		configCommand,
 		execCommand,
 		initCommand,
-		statsCommand,
-		configCommand,
+		oomCommand,
 		pauseCommand,
+		statsCommand,
 		unpauseCommand,
 	}
 

--- a/nsinit/oom.go
+++ b/nsinit/oom.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"log"
+
+	"github.com/codegangsta/cli"
+	"github.com/docker/libcontainer"
+)
+
+var oomCommand = cli.Command{
+	Name:   "oom",
+	Usage:  "display oom notifications for a container",
+	Action: oomAction,
+}
+
+func oomAction(context *cli.Context) {
+	state, err := libcontainer.GetState(dataPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	n, err := libcontainer.NotifyOnOOM(state)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _ = range n {
+		log.Printf("OOM notification received")
+	}
+}


### PR DESCRIPTION
This adds the ability to receive OOM notifications for a container via
the `nsinit oom` command.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>