### PR TITLE
cgroups: don't change a freezer state if an operation failed

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -124,11 +124,15 @@ func Freeze(c *cgroups.Cgroup, state cgroups.FreezerState) error {
 		return err
 	}
 
+	freezer := subsystems["freezer"]
+	err = freezer.Set(d)
+	if err != nil {
+		return err
+	}
+
 	c.Freezer = state
 
-	freezer := subsystems["freezer"]
-
-	return freezer.Set(d)
+	return nil
 }
 
 func GetPids(c *cgroups.Cgroup) ([]int, error) {


### PR DESCRIPTION
Signed-off-by: Andrey Vagin <avagin@openvz.org>