### PR TITLE
cgroups: set a freezer state before calling FreezerGroup.Set()

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -124,13 +124,15 @@ func Freeze(c *cgroups.Cgroup, state cgroups.FreezerState) error {
 		return err
 	}
 
+	prevState := c.Freezer
+	c.Freezer = state
+
 	freezer := subsystems["freezer"]
 	err = freezer.Set(d)
 	if err != nil {
+		c.Freezer = prevState
 		return err
 	}
-
-	c.Freezer = state
 
 	return nil
 }


### PR DESCRIPTION
My previous patch moved the setting of the freezer state after the Set()
command. It's wrong, because this command uses it, so we need to set the
freezer state before the command and rollback it in an error case.

Fixes: 13a5703d853f ("cgroups: don't change a freezer state if an operation failed")

Signed-off-by: Andrey Vagin <avagin@openvz.org>