### PR TITLE
cgroups: always create device cgroup on systemd

### DIFF
--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -133,7 +133,7 @@ func Apply(c *cgroups.Cgroup, pid int) (map[string]string, error) {
 	}
 
 	// -1 disables memorySwap
-	if c.MemorySwap >= 0 && (c.Memory != 0 || c.MemorySwap > 0) {
+	if c.MemorySwap >= 0 && c.Memory != 0 {
 		if err := joinMemory(c, pid); err != nil {
 			return nil, err
 		}

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -128,10 +128,8 @@ func Apply(c *cgroups.Cgroup, pid int) (map[string]string, error) {
 		return nil, err
 	}
 
-	if !c.AllowAllDevices {
-		if err := joinDevices(c, pid); err != nil {
-			return nil, err
-		}
+	if err := joinDevices(c, pid); err != nil {
+		return nil, err
 	}
 
 	// -1 disables memorySwap
@@ -272,13 +270,15 @@ func joinDevices(c *cgroups.Cgroup, pid int) error {
 		return err
 	}
 
-	if err := writeFile(path, "devices.deny", "a"); err != nil {
-		return err
-	}
-
-	for _, dev := range c.AllowedDevices {
-		if err := writeFile(path, "devices.allow", dev.GetCgroupAllowString()); err != nil {
+	if !c.AllowAllDevices {
+		if err := writeFile(path, "devices.deny", "a"); err != nil {
 			return err
+		}
+
+		for _, dev := range c.AllowedDevices {
+			if err := writeFile(path, "devices.allow", dev.GetCgroupAllowString()); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This is the same behavior as fs does.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>