### PR TITLE
Support read-only root filesystems

### DIFF
--- a/mount/init.go
+++ b/mount/init.go
@@ -79,7 +79,7 @@ func InitializeMountNamespace(rootfs, console string, sysReadonly bool, mountCon
 	if mountConfig.NoPivotRoot {
 		err = MsMoveRoot(rootfs)
 	} else {
-		err = PivotRoot(rootfs)
+		err = PivotRoot(rootfs, mountConfig.PivotDir)
 	}
 
 	if err != nil {

--- a/mount/mount_config.go
+++ b/mount/mount_config.go
@@ -13,6 +13,11 @@ type MountConfig struct {
 	// This is a common option when the container is running in ramdisk
 	NoPivotRoot bool `json:"no_pivot_root,omitempty"`
 
+	// PivotDir allows a custom directory inside the container's root filesystem to be used as pivot, when NoPivotRoot is not set.
+	// When a custom PivotDir not set, a temporary dir inside the root filesystem will be used. The pivot dir needs to be writeable.
+	// This is required when using read only root filesystems. In these cases, a read/writeable path can be (bind) mounted somewhere inside the root filesystem to act as pivot.
+	PivotDir string `json:"pivot_dir,omitempty"`
+
 	// ReadonlyFs will remount the container's rootfs as readonly where only externally mounted
 	// bind mounts are writtable
 	ReadonlyFs bool `json:"readonly_fs,omitempty"`


### PR DESCRIPTION
This allows users to prepare a read only filesystem with only a few writable subpaths inside it, to be used as the root filesystem by containers.

In particular, read only loopback images can now be used as the root filesystem, allowing multiple containers to share the same base (root) image and share pages without necessarily doing CoW layers.

All changes are backwards compatible, AFAICT. More details in commit messages.

Signed-off-by: Fabio Kung <fabio@heroku.com> (github: fabiokung)