### PR TITLE
nsenter: remove a proxy process

### DIFF
--- a/namespaces/execin.go
+++ b/namespaces/execin.go
@@ -16,6 +16,10 @@ import (
 	"github.com/docker/libcontainer/system"
 )
 
+type pid struct {
+	Pid int `json:"Pid"`
+}
+
 // ExecIn reexec's cmd with _LIBCONTAINER_INITPID=PID so that it is able to run the
 // setns code in a single threaded environment joining the existing containers' namespaces.
 func ExecIn(args []string, env []string, console string, cmd *exec.Cmd, container *configs.Config, state *configs.State) (int, error) {
@@ -36,11 +40,36 @@ func ExecIn(args []string, env []string, console string, cmd *exec.Cmd, containe
 	}
 	child.Close()
 
+	s, err := cmd.Process.Wait()
+	if err != nil {
+		return -1, err
+	}
+	if !s.Success() {
+		return -1, &exec.ExitError{s}
+	}
+
+	decoder := json.NewDecoder(parent)
+	var pid *pid
+
+	if err := decoder.Decode(&pid); err != nil {
+		return -1, err
+	}
+
+	p, err := os.FindProcess(pid.Pid)
+	if err != nil {
+		return -1, err
+	}
+
 	terminate := func(terr error) (int, error) {
 		// TODO: log the errors for kill and wait
-		cmd.Process.Kill()
-		cmd.Wait()
+		p.Kill()
+		p.Wait()
 		return -1, terr
+	}
+
+	// Enter cgroups.
+	if err := EnterCgroups(state, pid.Pid); err != nil {
+		return terminate(err)
 	}
 
 	encoder := json.NewEncoder(parent)
@@ -58,12 +87,7 @@ func ExecIn(args []string, env []string, console string, cmd *exec.Cmd, containe
 		return terminate(err)
 	}
 
-	// Enter cgroups.
-	if err := EnterCgroups(state, cmd.Process.Pid); err != nil {
-		return terminate(err)
-	}
-
-	return cmd.Process.Pid, nil
+	return pid.Pid, nil
 }
 
 // Finalize entering into a container and execute a specified command

--- a/namespaces/execin.go
+++ b/namespaces/execin.go
@@ -63,10 +63,6 @@ func ExecIn(args []string, env []string, console string, cmd *exec.Cmd, containe
 		return terminate(err)
 	}
 
-	if err := json.NewEncoder(parent).Encode(container); err != nil {
-		return terminate(err)
-	}
-
 	return cmd.Process.Pid, nil
 }
 

--- a/namespaces/nsenter/nsenter.go
+++ b/namespaces/nsenter/nsenter.go
@@ -3,7 +3,9 @@
 package nsenter
 
 /*
-__attribute__((constructor)) init() {
+#cgo CFLAGS: -Wall
+extern void nsexec();
+void __attribute__((constructor)) init() {
 	nsexec();
 }
 */

--- a/namespaces/nsenter/nsenter_test.go
+++ b/namespaces/nsenter/nsenter_test.go
@@ -1,0 +1,99 @@
+package nsenter
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+type pid struct {
+	Pid int `json:"Pid"`
+}
+
+func TestNsenterAlivePid(t *testing.T) {
+	args := []string{"nsenter-exec"}
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe %v", err)
+	}
+
+	cmd := &exec.Cmd{
+		Path:       os.Args[0],
+		Args:       args,
+		ExtraFiles: []*os.File{w},
+		Env:        []string{fmt.Sprintf("_LIBCONTAINER_INITPID=%d", os.Getpid())},
+	}
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("nsenter failed to start %v", err)
+	}
+	w.Close()
+
+	decoder := json.NewDecoder(r)
+	var pid *pid
+
+	if err := decoder.Decode(&pid); err != nil {
+		t.Fatalf("%v", err)
+	}
+
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("nsenter exits with a non-zero exit status")
+	}
+	p, err := os.FindProcess(pid.Pid)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	p.Wait()
+}
+
+func TestNsenterInvalidPid(t *testing.T) {
+	args := []string{"nsenter-exec"}
+
+	cmd := &exec.Cmd{
+		Path: os.Args[0],
+		Args: args,
+		Env:  []string{"_LIBCONTAINER_INITPID=-1"},
+	}
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("nsenter exits with a zero exit status")
+	}
+}
+
+func TestNsenterDeadPid(t *testing.T) {
+
+	c := make(chan os.Signal)
+	signal.Notify(c, syscall.SIGCHLD)
+	dead_cmd := exec.Command("true")
+	if err := dead_cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer dead_cmd.Wait()
+	<-c // dead_cmd is zombie
+
+	args := []string{"nsenter-exec"}
+
+	cmd := &exec.Cmd{
+		Path: os.Args[0],
+		Args: args,
+		Env:  []string{fmt.Sprintf("_LIBCONTAINER_INITPID=%d", dead_cmd.Process.Pid)},
+	}
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("nsenter exits with a zero exit status")
+	}
+}
+
+func init() {
+	if strings.HasPrefix(os.Args[0], "nsenter-") {
+		os.Exit(0)
+	}
+	return
+}


### PR DESCRIPTION
Currently nsexec() creates a proxy process to enter into a pid namespace.
It isn't good, because we need to proxy an exit code and signals.
We can use CLONE_PARENT to fork a process with the right parent.

Signed-off-by: Andrey Vagin <avagin@openvz.org>