### PR TITLE
Add enviornment variable `DISABLE_SYSTEMD_CGROUPS` so you can optionally...

### DIFF
--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -41,6 +41,10 @@ func newProp(name string, units interface{}) systemd.Property {
 }
 
 func UseSystemd() bool {
+	if disableSystemd := os.Getenv("DISABLE_SYSTEMD_CGROUPS"); disableSystemd != "" {
+		return false
+
+	}
 	s, err := os.Stat("/run/systemd/system")
 	if err != nil || !s.IsDir() {
 		return false


### PR DESCRIPTION
... not use systemd cgroups.

Just because a user uses systemd doesn't mean they want to use systemd's
cgroups.
