### PR TITLE
Allow a container's cgroups driver to be configured.

### DIFF
--- a/cgroups/cgroups.go
+++ b/cgroups/cgroups.go
@@ -54,4 +54,5 @@ type Cgroup struct {
 	BlkioWeight       int64             `json:"blkio_weight,omitempty"`       // Specifies per cgroup weight, range is from 10 to 1000.
 	Freezer           FreezerState      `json:"freezer,omitempty"`            // set the freeze value for the process
 	Slice             string            `json:"slice,omitempty"`              // Parent slice to use for systemd
+	Driver            string            `json:"driver,omitempty"`             // Configure the driver that should manage the container's cgroups (default: cgroupfs, systemd)
 }

--- a/namespaces/exec.go
+++ b/namespaces/exec.go
@@ -156,7 +156,7 @@ func killAllPids(container *libcontainer.Config) error {
 		freeze  = fs.Freeze
 		getPids = fs.GetPids
 	)
-	if systemd.UseSystemd() {
+	if container.Cgroups.Driver == "systemd" {
 		freeze = systemd.Freeze
 		getPids = systemd.GetPids
 	}
@@ -327,7 +327,7 @@ func DefaultSetupCommand(container *libcontainer.Config, console, dataPath, init
 func SetupCgroups(container *libcontainer.Config, nspid int) (map[string]string, error) {
 	if container.Cgroups != nil {
 		c := container.Cgroups
-		if systemd.UseSystemd() {
+		if container.Cgroups.Driver == "systemd" {
 			return systemd.Apply(c, nspid)
 		}
 		return fs.Apply(c, nspid)

--- a/nsinit/pause.go
+++ b/nsinit/pause.go
@@ -39,7 +39,7 @@ func toggle(state cgroups.FreezerState) error {
 		return err
 	}
 
-	if systemd.UseSystemd() {
+	if container.Cgroups.Driver == "systemd" {
 		err = systemd.Freeze(container.Cgroups, state)
 	} else {
 		err = fs.Freeze(container.Cgroups, state)


### PR DESCRIPTION
This adds a `Driver` to the `Cgroups` struct. I am unsure if this is the preferred way to implement this. There is a previous discussion on https://github.com/docker/libcontainer/pull/350 as to whether this should be global or per container. I am open to other implementations :D 
Also I tried to have a `func (c *Cgroup) GetDriver()` function to cleanup all the `if container.Cgroups.Driver == "systemd" && systemd.UseSystemd()` but because it required calling `systemd.UseSystemd()` in cgroups.cgroups.go, there was a circular dependency problem :/
So open to other ideas.