### PR TITLE
namespaces: allow to use pid namespace without mount namespace

### DIFF
--- a/security/capabilities/capabilities.go
+++ b/security/capabilities/capabilities.go
@@ -1,8 +1,6 @@
 package capabilities
 
 import (
-	"os"
-
 	"github.com/syndtr/gocapability/capability"
 )
 
@@ -11,7 +9,7 @@ const allCapabilityTypes = capability.CAPS | capability.BOUNDS
 // DropBoundingSet drops the capability bounding set to those specified in the
 // container configuration.
 func DropBoundingSet(capabilities []string) error {
-	c, err := capability.NewPid(os.Getpid())
+	c, err := capability.NewPid(0)
 	if err != nil {
 		return err
 	}
@@ -29,7 +27,7 @@ func DropBoundingSet(capabilities []string) error {
 
 // DropCapabilities drops all capabilities for the current process except those specified in the container configuration.
 func DropCapabilities(capList []string) error {
-	c, err := capability.NewPid(os.Getpid())
+	c, err := capability.NewPid(0)
 	if err != nil {
 		return err
 	}

--- a/update-vendor.sh
+++ b/update-vendor.sh
@@ -43,6 +43,6 @@ clone() {
 clone git github.com/codegangsta/cli 1.1.0
 clone git github.com/coreos/go-systemd v2
 clone git github.com/godbus/dbus v2
-clone git github.com/syndtr/gocapability 3c85049eae
+clone git github.com/syndtr/gocapability 1cf3ac4dc4
 
 # intentionally not vendoring Docker itself...  that'd be a circle :)

--- a/vendor/src/github.com/syndtr/gocapability/capability/capability.go
+++ b/vendor/src/github.com/syndtr/gocapability/capability/capability.go
@@ -60,7 +60,8 @@ type Capabilities interface {
 	Apply(kind CapType) error
 }
 
-// NewPid create new initialized Capabilities object for given pid.
+// NewPid create new initialized Capabilities object for given pid when it
+// is nonzero, or for the current pid if pid is 0
 func NewPid(pid int) (Capabilities, error) {
 	return newPid(pid)
 }

--- a/vendor/src/github.com/syndtr/gocapability/capability/capability_linux.go
+++ b/vendor/src/github.com/syndtr/gocapability/capability/capability_linux.go
@@ -351,7 +351,15 @@ func (c *capsV3) Load() (err error) {
 		return
 	}
 
-	f, err := os.Open(fmt.Sprintf("/proc/%d/status", c.hdr.pid))
+	var status_path string
+
+	if c.hdr.pid == 0 {
+		status_path = fmt.Sprintf("/proc/self/status")
+	} else {
+		status_path = fmt.Sprintf("/proc/%d/status", c.hdr.pid)
+	}
+
+	f, err := os.Open(status_path)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
The gocapability package uses /proc/PID/status to get a bounding set.
If a container uses pidns without mntns, it sees /proc from the host
namespace, but the process doesn't know its own pid in this namespace.

In this case it can use /proc/self/status, which is always the right one.

Signed-off-by: Andrew Vagin <avagin@openvz.org>