### PR TITLE
rename Set to Apply

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -58,7 +58,7 @@ type subsystem interface {
 	// Removes the cgroup represented by 'data'.
 	Remove(*data) error
 	// Creates and joins the cgroup represented by data.
-	Set(*data) error
+	Apply(*data) error
 }
 
 type data struct {
@@ -81,7 +81,7 @@ func Apply(c *cgroups.Cgroup, pid int) (map[string]string, error) {
 		}
 	}()
 	for name, sys := range subsystems {
-		if err := sys.Set(d); err != nil {
+		if err := sys.Apply(d); err != nil {
 			return nil, err
 		}
 		// FIXME: Apply should, ideally, be reentrant or be broken up into a separate
@@ -109,7 +109,7 @@ func ApplyDevices(c *cgroups.Cgroup, pid int) error {
 
 	devices := subsystems["devices"]
 
-	return devices.Set(d)
+	return devices.Apply(d)
 }
 
 func GetStats(systemPaths map[string]string) (*cgroups.Stats, error) {
@@ -139,7 +139,7 @@ func Freeze(c *cgroups.Cgroup, state cgroups.FreezerState) error {
 	c.Freezer = state
 
 	freezer := subsystems["freezer"]
-	err = freezer.Set(d)
+	err = freezer.Apply(d)
 	if err != nil {
 		c.Freezer = prevState
 		return err

--- a/cgroups/fs/blkio.go
+++ b/cgroups/fs/blkio.go
@@ -14,7 +14,7 @@ import (
 type BlkioGroup struct {
 }
 
-func (s *BlkioGroup) Set(d *data) error {
+func (s *BlkioGroup) Apply(d *data) error {
 	dir, err := d.join("blkio")
 	if err != nil && !cgroups.IsNotFound(err) {
 		return err

--- a/cgroups/fs/cpu.go
+++ b/cgroups/fs/cpu.go
@@ -12,7 +12,7 @@ import (
 type CpuGroup struct {
 }
 
-func (s *CpuGroup) Set(d *data) error {
+func (s *CpuGroup) Apply(d *data) error {
 	// We always want to join the cpu group, to allow fair cpu scheduling
 	// on a container basis
 	dir, err := d.join("cpu")

--- a/cgroups/fs/cpuacct.go
+++ b/cgroups/fs/cpuacct.go
@@ -21,7 +21,7 @@ var clockTicks = uint64(system.GetClockTicks())
 type CpuacctGroup struct {
 }
 
-func (s *CpuacctGroup) Set(d *data) error {
+func (s *CpuacctGroup) Apply(d *data) error {
 	// we just want to join this group even though we don't set anything
 	if _, err := d.join("cpuacct"); err != nil && !cgroups.IsNotFound(err) {
 		return err

--- a/cgroups/fs/cpuset.go
+++ b/cgroups/fs/cpuset.go
@@ -13,12 +13,12 @@ import (
 type CpusetGroup struct {
 }
 
-func (s *CpusetGroup) Set(d *data) error {
+func (s *CpusetGroup) Apply(d *data) error {
 	dir, err := d.path("cpuset")
 	if err != nil {
 		return err
 	}
-	return s.SetDir(dir, d.c.CpusetCpus, d.c.CpusetMems, d.pid)
+	return s.ApplyDir(dir, d.c.CpusetCpus, d.c.CpusetMems, d.pid)
 }
 
 func (s *CpusetGroup) Remove(d *data) error {
@@ -29,7 +29,7 @@ func (s *CpusetGroup) GetStats(path string, stats *cgroups.Stats) error {
 	return nil
 }
 
-func (s *CpusetGroup) SetDir(dir, cpus string, mems string, pid int) error {
+func (s *CpusetGroup) ApplyDir(dir, cpus string, mems string, pid int) error {
 	if err := s.ensureParent(dir); err != nil {
 		return err
 	}

--- a/cgroups/fs/devices.go
+++ b/cgroups/fs/devices.go
@@ -5,7 +5,7 @@ import "github.com/docker/libcontainer/cgroups"
 type DevicesGroup struct {
 }
 
-func (s *DevicesGroup) Set(d *data) error {
+func (s *DevicesGroup) Apply(d *data) error {
 	dir, err := d.join("devices")
 	if err != nil {
 		return err

--- a/cgroups/fs/freezer.go
+++ b/cgroups/fs/freezer.go
@@ -10,7 +10,7 @@ import (
 type FreezerGroup struct {
 }
 
-func (s *FreezerGroup) Set(d *data) error {
+func (s *FreezerGroup) Apply(d *data) error {
 	switch d.c.Freezer {
 	case cgroups.Frozen, cgroups.Thawed:
 		dir, err := d.path("freezer")

--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -13,7 +13,7 @@ import (
 type MemoryGroup struct {
 }
 
-func (s *MemoryGroup) Set(d *data) error {
+func (s *MemoryGroup) Apply(d *data) error {
 	dir, err := d.join("memory")
 	// only return an error for memory if it was specified
 	if err != nil && (d.c.Memory != 0 || d.c.MemoryReservation != 0 || d.c.MemorySwap != 0) {

--- a/cgroups/fs/perf_event.go
+++ b/cgroups/fs/perf_event.go
@@ -7,7 +7,7 @@ import (
 type PerfEventGroup struct {
 }
 
-func (s *PerfEventGroup) Set(d *data) error {
+func (s *PerfEventGroup) Apply(d *data) error {
 	// we just want to join this group even though we don't set anything
 	if _, err := d.join("perf_event"); err != nil && !cgroups.IsNotFound(err) {
 		return err

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -336,5 +336,5 @@ func joinCpuset(c *cgroups.Cgroup, pid int) error {
 
 	s := &fs.CpusetGroup{}
 
-	return s.SetDir(path, c.CpusetCpus, c.CpusetMems, pid)
+	return s.ApplyDir(path, c.CpusetCpus, c.CpusetMems, pid)
 }


### PR DESCRIPTION
The name `Set` would be used to do dymanic changes of resource configs
in the future. For now, `Apply` also makes more sense.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>