### PR TITLE
Resurrect hairpin NAT

### DIFF
--- a/network/types.go
+++ b/network/types.go
@@ -38,6 +38,12 @@ type Network struct {
 	// container's interfaces if a pair is created, specifically in the case of type veth
 	// Note: This does not apply to loopback interfaces.
 	TxQueueLen int `json:"txqueuelen,omitempty"`
+
+	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
+	// bridge port in the case of type veth
+	// Note: This is unsupported on some systems.
+	// Note: This does not apply to loopback interfaces.
+	HairpinMode bool `json:"hairpin_mode"`
 }
 
 // Struct describing the network specific runtime state that will be maintained by libcontainer for all running containers

--- a/network/veth.go
+++ b/network/veth.go
@@ -39,6 +39,9 @@ func (v *Veth) Create(n *Network, nspid int, networkState *NetworkState) error {
 	if err := SetMtu(name1, n.Mtu); err != nil {
 		return err
 	}
+	if err := SetHairpinMode(name1, true); err != nil {
+		return err
+	}
 	if err := InterfaceUp(name1); err != nil {
 		return err
 	}

--- a/network/veth.go
+++ b/network/veth.go
@@ -39,8 +39,10 @@ func (v *Veth) Create(n *Network, nspid int, networkState *NetworkState) error {
 	if err := SetMtu(name1, n.Mtu); err != nil {
 		return err
 	}
-	if err := SetHairpinMode(name1, true); err != nil {
-		return err
+	if n.HairpinMode {
+		if err := SetHairpinMode(name1, true); err != nil {
+			return err
+		}
 	}
 	if err := InterfaceUp(name1); err != nil {
 		return err


### PR DESCRIPTION
We're throwing a new attempt at removing the userland proxy from Docker. The blocking issue we discovered last time was that hairpin NAT was not available on some systems (see docker/docker#9134).

This PR reintroduces @phemmer work from #62 and adds the ability to enable Hairpin NAT on a per-network basis using the `Network.HairpinNAT` flag (disabled by default).