### PR TITLE
handle SIGCHLD when running as child subreaper

### DIFF
--- a/namespaces/nsenter/nsenter.c
+++ b/namespaces/nsenter/nsenter.c
@@ -12,6 +12,7 @@
 #include <string.h>
 #include <sys/prctl.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #include <getopt.h>
 
@@ -84,6 +85,12 @@ void print_usage()
 		"nsenter --nspid <pid> --console <console> -- cmd1 arg1 arg2...\n");
 }
 
+void child_handler(int sig)
+{
+	while (waitpid(-1, NULL, WNOHANG) > 0) {
+	}
+}
+
 void nsenter()
 {
 	int argc, c;
@@ -100,6 +107,15 @@ void nsenter()
 #ifdef PR_SET_CHILD_SUBREAPER
 	if (prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) == -1) {
 		pr_perror("Failed to set child subreaper");
+		exit(1);
+	}
+	// setup SIGCHLD handler to reap zombie processes
+	struct sigaction sa;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_handler = &child_handler;
+	sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
+	if (sigaction(SIGCHLD, &sa, NULL) == -1) {
+		pr_perror("Failed to set SIGCHLD handler");
 		exit(1);
 	}
 #endif


### PR DESCRIPTION
When running under child subreaper mode, it's useful for nsenter to be able to reap child processes. We have seen cases where spawned user processes were not reaped properly (https://github.com/creationix/nvm/issues/650)

I dont see how we can write a test case for this yet. Manual steps to reproduce this are:

```
# terminal 1
> docker pull soareschen/ubuntu-zsh
> docker run -it --rm --name test-nvm soareschen/ubuntu-zsh zsh
> source ~/.nvm/nvm.sh
> ps auxf # no defunct processes

# terminal 2
> docker exec -it test-nvm zsh
> source ~/.nvm/nvm.sh
> ps auxf # lots of defunct processes before this patch, and no defunct processes after
```

Thanks @soareschen for the test image