### PR TITLE
nsenter: noop reference to C constructor

### DIFF
--- a/nsenter/nsenter.go
+++ b/nsenter/nsenter.go
@@ -10,3 +10,16 @@ void __attribute__((constructor)) init() {
 }
 */
 import "C"
+
+// AlwaysFalse is here to stay false
+// (and be exported so the compiler doesn't optimize out its reference)
+var AlwaysFalse bool
+
+func init() {
+	if AlwaysFalse {
+		// by referencing this C init() in a noop test, it will ensure the compiler
+		// links in the C function.
+		// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65134
+		C.init()
+	}
+}


### PR DESCRIPTION
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65134
Workaround suggested by iant

Reported here https://github.com/docker/docker/issues/9207#issuecomment-75354189

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>