### PR TITLE
process: add Wait() and Pid() methods

### DIFF
--- a/container.go
+++ b/container.go
@@ -5,8 +5,6 @@
 package libcontainer
 
 import (
-	"os"
-
 	"github.com/docker/libcontainer/configs"
 )
 
@@ -99,7 +97,7 @@ type Container interface {
 	// ConfigInvalid - config is invalid,
 	// ContainerPaused - Container is paused,
 	// Systemerror - System error.
-	Start(process *Process) (pid int, err error)
+	Start(process *Process) (err error)
 
 	// Destroys the container after killing all running processes.
 	//
@@ -128,14 +126,6 @@ type Container interface {
 	// ContainerDestroyed - Container no longer exists,
 	// Systemerror - System error.
 	Resume() error
-
-	// Signal sends the specified signal to the init process of the container.
-	//
-	// errors:
-	// ContainerDestroyed - Container no longer exists,
-	// ContainerPaused - Container is paused,
-	// Systemerror - System error.
-	Signal(signal os.Signal) error
 
 	// NotifyOOM returns a read-only channel signaling when the container receives an OOM notification.
 	//

--- a/error.go
+++ b/error.go
@@ -17,6 +17,9 @@ const (
 	ContainerNotStopped
 	ContainerNotRunning
 
+	// Process errors
+	ProcessNotExecuted
+
 	// Common errors
 	ConfigInvalid
 	SystemError

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -97,15 +97,11 @@ func runContainer(config *configs.Config, console string, args ...string) (buffe
 		Stderr: buffers.Stderr,
 	}
 
-	pid, err := container.Start(process)
+	err = container.Start(process)
 	if err != nil {
 		return nil, -1, err
 	}
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return nil, -1, err
-	}
-	ps, err := p.Wait()
+	ps, err := process.Wait()
 	if err != nil {
 		return nil, -1, err
 	}


### PR DESCRIPTION
Currently we have a problem when buffers are used for std file
descriptors.  These buffers are filled from goroutines (Cmd.goroutine),
and we need to wait them to be sure that all data have been copied.

Signed-off-by: Andrew Vagin <avagin@openvz.org>