### PR TITLE
Use configs.NamespaceType as key for State.NamespacePathes

### DIFF
--- a/container.go
+++ b/container.go
@@ -40,9 +40,9 @@ type State struct {
 	// with the value as the path.
 	CgroupPaths map[string]string `json:"cgroup_paths"`
 
-	// NamespacePaths are filepaths to the container's namespaces. Key is the namespace name
+	// NamespacePaths are filepaths to the container's namespaces. Key is the namespace type
 	// with the value as the path.
-	NamespacePaths map[string]string `json:"namespace_paths"`
+	NamespacePaths map[configs.NamespaceType]string `json:"namespace_paths"`
 
 	// Config is the container's configuration.
 	Config configs.Config `json:"config"`

--- a/container_linux.go
+++ b/container_linux.go
@@ -281,10 +281,10 @@ func (c *linuxContainer) currentState() (*State, error) {
 		InitProcessPid:       c.initProcess.pid(),
 		InitProcessStartTime: startTime,
 		CgroupPaths:          c.cgroupManager.GetPaths(),
-		NamespacePaths:       make(map[string]string),
+		NamespacePaths:       make(map[configs.NamespaceType]string),
 	}
 	for _, ns := range c.config.Namespaces {
-		state.NamespacePaths[string(ns.Type)] = ns.GetPath(c.initProcess.pid())
+		state.NamespacePaths[ns.Type] = ns.GetPath(c.initProcess.pid())
 	}
 	return state, nil
 }

--- a/container_test_linux.go
+++ b/container_test_linux.go
@@ -163,7 +163,7 @@ func TestGetContainerState(t *testing.T) {
 		t.Fatalf("expected memory path %q but received %q", expectedMemoryPath, memPath)
 	}
 	for _, ns := range container.config.Namespaces {
-		path := state.NamespacePaths[string(ns.Type)]
+		path := state.NamespacePaths[ns.Type]
 		if path == "" {
 			t.Fatalf("expected non nil namespace path for %s", ns.Type)
 		}


### PR DESCRIPTION
I think this is more convenient because for working with namespaces we
using configs.NamespaceType.