### PR TITLE
Exit related cleanup

### DIFF
--- a/nsinit/exec.go
+++ b/nsinit/exec.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
 
@@ -81,13 +82,19 @@ func execAction(context *cli.Context) {
 		}
 		fatal(err)
 	}
+
 	status, err := process.Wait()
 	if err != nil {
-		tty.Close()
-		if created {
-			container.Destroy()
+		exitError, ok := err.(*exec.ExitError)
+		if ok {
+			status = exitError.ProcessState
+		} else {
+			tty.Close()
+			if created {
+				container.Destroy()
+			}
+			fatal(err)
 		}
-		fatal(err)
 	}
 	if created {
 		if err := container.Destroy(); err != nil {

--- a/nsinit/utils.go
+++ b/nsinit/utils.go
@@ -50,6 +50,7 @@ func fatal(err error) {
 		os.Exit(1)
 	}
 	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
 }
 
 func fatalf(t string, v ...interface{}) {


### PR DESCRIPTION
Adds missing exit to fatal function.
Extracts ProcessState when we get ExitError.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>