### PR TITLE
Make possible to call config methods on values

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -103,7 +103,7 @@ type Config struct {
 
 // Gets the root uid for the process on host which could be non-zero
 // when user namespaces are enabled.
-func (c *Config) HostUID() (int, error) {
+func (c Config) HostUID() (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
 		if c.UidMappings == nil {
 			return -1, fmt.Errorf("User namespaces enabled, but no user mappings found.")
@@ -120,7 +120,7 @@ func (c *Config) HostUID() (int, error) {
 
 // Gets the root uid for the process on host which could be non-zero
 // when user namespaces are enabled.
-func (c *Config) HostGID() (int, error) {
+func (c Config) HostGID() (int, error) {
 	if c.Namespaces.Contains(NEWUSER) {
 		if c.GidMappings == nil {
 			return -1, fmt.Errorf("User namespaces enabled, but no gid mappings found.")
@@ -137,7 +137,7 @@ func (c *Config) HostGID() (int, error) {
 
 // Utility function that gets a host ID for a container ID from user namespace map
 // if that ID is present in the map.
-func (c *Config) hostIDFromMapping(containerID int, uMap []IDMap) (int, bool) {
+func (c Config) hostIDFromMapping(containerID int, uMap []IDMap) (int, bool) {
 	for _, m := range uMap {
 		if (containerID >= m.ContainerID) && (containerID <= (m.ContainerID + m.Size - 1)) {
 			hostID := m.HostID + (containerID - m.ContainerID)


### PR DESCRIPTION
Because container.Config() returns values and you can't get pointer from
function call immediately. So it is impossible to call
container.Config().HostUID().