### PR TITLE
cgroups: add support for oom control

### DIFF
--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -56,6 +56,12 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 		}
 	}
 
+	if cgroup.OomKillDisable {
+		if err := writeFile(path, "memory.oom_control", "1"); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/cgroups/fs/memory_test.go
+++ b/cgroups/fs/memory_test.go
@@ -173,3 +173,30 @@ func TestMemoryStatsBadMaxUsageFile(t *testing.T) {
 		t.Fatal("Expected failure")
 	}
 }
+
+func TestMemorySetOomControl(t *testing.T) {
+	helper := NewCgroupTestUtil("memory", t)
+	defer helper.cleanup()
+
+	const (
+		oom_kill_disable = 1 // disable oom killer, default is 0
+	)
+
+	helper.writeFileContents(map[string]string{
+		"memory.oom_control": strconv.Itoa(oom_kill_disable),
+	})
+
+	memory := &MemoryGroup{}
+	if err := memory.Set(helper.CgroupPath, helper.CgroupData.c); err != nil {
+		t.Fatal(err)
+	}
+
+	value, err := getCgroupParamUint(helper.CgroupPath, "memory.oom_control")
+	if err != nil {
+		t.Fatalf("Failed to parse memory.oom_control - %s", err)
+	}
+
+	if value != oom_kill_disable {
+		t.Fatalf("Got the wrong value, set memory.oom_control failed.")
+	}
+}

--- a/configs/cgroup.go
+++ b/configs/cgroup.go
@@ -51,4 +51,7 @@ type Cgroup struct {
 
 	// Parent slice to use for systemd TODO: remove in favor or parent
 	Slice string `json:"slice"`
+
+	// Whether to disable OOM Killer
+	OomKillDisable bool `json:"oom_kill_disable"`
 }


### PR DESCRIPTION
Redo #412 
This patch add support for diable OOM Killer.

Signed-off-by: Hu Keping <hukeping@huawei.com>