### PR TITLE
Setup environment for processes with os.Environ()

### DIFF
--- a/container_linux.go
+++ b/container_linux.go
@@ -206,7 +206,7 @@ func (c *linuxContainer) Destroy() error {
 		return err
 	}
 	if status != Destroyed {
-		return newGenericError(nil, ContainerNotStopped)
+		return newGenericError(fmt.Errorf("container is not destroyed"), ContainerNotStopped)
 	}
 	if !c.config.Namespaces.Contains(configs.NEWPID) {
 		if err := killCgroupProcesses(c.cgroupManager); err != nil {

--- a/generic_error.go
+++ b/generic_error.go
@@ -25,26 +25,32 @@ func newGenericError(err error, c ErrorCode) Error {
 	if le, ok := err.(Error); ok {
 		return le
 	}
-	return &genericError{
+	gerr := &genericError{
 		Timestamp: time.Now(),
 		Err:       err,
-		Message:   err.Error(),
 		ECode:     c,
 		Stack:     stacktrace.Capture(1),
 	}
+	if err != nil {
+		gerr.Message = err.Error()
+	}
+	return gerr
 }
 
 func newSystemError(err error) Error {
 	if le, ok := err.(Error); ok {
 		return le
 	}
-	return &genericError{
+	gerr := &genericError{
 		Timestamp: time.Now(),
 		Err:       err,
 		ECode:     SystemError,
-		Message:   err.Error(),
 		Stack:     stacktrace.Capture(1),
 	}
+	if err != nil {
+		gerr.Message = err.Error()
+	}
+	return gerr
 }
 
 type genericError struct {

--- a/integration/execin_test.go
+++ b/integration/execin_test.go
@@ -66,6 +66,74 @@ func TestExecIn(t *testing.T) {
 	}
 }
 
+func TestExecInEnvironment(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	rootfs, err := newRootfs()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer remove(rootfs)
+	config := newTemplateConfig(rootfs)
+	container, err := newContainer(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer container.Destroy()
+
+	// Execute a first process in the container
+	stdinR, stdinW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	process := &libcontainer.Process{
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR,
+	}
+	err = container.Start(process)
+	stdinR.Close()
+	defer stdinW.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buffers := newStdBuffers()
+	ps := &libcontainer.Process{
+		Args: []string{"env"},
+		Env: []string{
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"DEBUG=true",
+			"DEBUG=false",
+			"ENV=test",
+		},
+		Stdin:  buffers.Stdin,
+		Stdout: buffers.Stdout,
+		Stderr: buffers.Stderr,
+	}
+	err = container.Start(ps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ps.Wait(); err != nil {
+		out := buffers.Stdout.String()
+		t.Fatal(err, out)
+	}
+	stdinW.Close()
+	if _, err := process.Wait(); err != nil {
+		t.Log(err)
+	}
+	out := buffers.Stdout.String()
+	// check execin's process environment
+	if !strings.Contains(out, "DEBUG=false") ||
+		!strings.Contains(out, "ENV=test") ||
+		!strings.Contains(out, "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin") ||
+		strings.Contains(out, "DEBUG=true") {
+		t.Fatalf("unexpected running process, output %q", out)
+	}
+}
+
 func TestExecInRlimit(t *testing.T) {
 	if testing.Short() {
 		return

--- a/process.go
+++ b/process.go
@@ -1,6 +1,7 @@
 package libcontainer
 
 import (
+	"fmt"
 	"io"
 	"os"
 )
@@ -46,7 +47,7 @@ type Process struct {
 // Wait releases any resources associated with the Process
 func (p Process) Wait() (*os.ProcessState, error) {
 	if p.ops == nil {
-		return nil, newGenericError(nil, ProcessNotExecuted)
+		return nil, newGenericError(fmt.Errorf("invalid process"), ProcessNotExecuted)
 	}
 	return p.ops.wait()
 }
@@ -54,7 +55,7 @@ func (p Process) Wait() (*os.ProcessState, error) {
 // Pid returns the process ID
 func (p Process) Pid() (int, error) {
 	if p.ops == nil {
-		return -1, newGenericError(nil, ProcessNotExecuted)
+		return -1, newGenericError(fmt.Errorf("invalid process"), ProcessNotExecuted)
 	}
 	return p.ops.pid(), nil
 }
@@ -62,7 +63,7 @@ func (p Process) Pid() (int, error) {
 // Signal sends a signal to the Process.
 func (p Process) Signal(sig os.Signal) error {
 	if p.ops == nil {
-		return newGenericError(nil, ProcessNotExecuted)
+		return newGenericError(fmt.Errorf("invalid process"), ProcessNotExecuted)
 	}
 	return p.ops.signal(sig)
 }

--- a/setns_init_linux.go
+++ b/setns_init_linux.go
@@ -3,6 +3,8 @@
 package libcontainer
 
 import (
+	"os"
+
 	"github.com/docker/libcontainer/apparmor"
 	"github.com/docker/libcontainer/label"
 	"github.com/docker/libcontainer/system"
@@ -29,5 +31,5 @@ func (l *linuxSetnsInit) Init() error {
 			return err
 		}
 	}
-	return system.Execv(l.config.Args[0], l.config.Args[0:], l.config.Env)
+	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
 }

--- a/standard_init_linux.go
+++ b/standard_init_linux.go
@@ -3,6 +3,7 @@
 package libcontainer
 
 import (
+	"os"
 	"syscall"
 
 	"github.com/docker/libcontainer/apparmor"
@@ -89,5 +90,5 @@ func (l *linuxStandardInit) Init() error {
 	if syscall.Getppid() == 1 {
 		return syscall.Kill(syscall.Getpid(), syscall.SIGKILL)
 	}
-	return system.Execv(l.config.Args[0], l.config.Args[0:], l.config.Env)
+	return system.Execv(l.config.Args[0], l.config.Args[0:], os.Environ())
 }


### PR DESCRIPTION
- `genericError` constructor should not panic when we pass in `nil` error, but we should not pass nil error actually. This fixes it.
- Instead of taking the raw config.Env, we use `os.Environ()` when execve which works correctly because the environment has been setup properly with `newContainerInit`
