### PR TITLE
Make NetworkInterface public

### DIFF
--- a/network_linux.go
+++ b/network_linux.go
@@ -37,8 +37,8 @@ func getStrategy(tpe string) (networkStrategy, error) {
 }
 
 // Returns the network statistics for the network interfaces represented by the NetworkRuntimeInfo.
-func getNetworkInterfaceStats(interfaceName string) (*networkInterface, error) {
-	out := &networkInterface{Name: interfaceName}
+func getNetworkInterfaceStats(interfaceName string) (*NetworkInterface, error) {
+	out := &NetworkInterface{Name: interfaceName}
 	// This can happen if the network runtime information is missing - possible if the
 	// container was created by an old version of libcontainer.
 	if interfaceName == "" {

--- a/stats.go
+++ b/stats.go
@@ -3,11 +3,11 @@ package libcontainer
 import "github.com/docker/libcontainer/cgroups"
 
 type Stats struct {
-	Interfaces  []*networkInterface
+	Interfaces  []*NetworkInterface
 	CgroupStats *cgroups.Stats
 }
 
-type networkInterface struct {
+type NetworkInterface struct {
 	// Name is the name of the network interface.
 	Name string
 


### PR DESCRIPTION
In other case it is impossible to implement Stats() method from
interface outside libcontainer.