### PR TITLE
Fix panic when genericError constructor gets nil error

### DIFF
--- a/container_linux.go
+++ b/container_linux.go
@@ -206,7 +206,7 @@ func (c *linuxContainer) Destroy() error {
 		return err
 	}
 	if status != Destroyed {
-		return newGenericError(nil, ContainerNotStopped)
+		return newGenericError(fmt.Errorf("container is not destroyed"), ContainerNotStopped)
 	}
 	if !c.config.Namespaces.Contains(configs.NEWPID) {
 		if err := killCgroupProcesses(c.cgroupManager); err != nil {

--- a/generic_error.go
+++ b/generic_error.go
@@ -25,26 +25,32 @@ func newGenericError(err error, c ErrorCode) Error {
 	if le, ok := err.(Error); ok {
 		return le
 	}
-	return &genericError{
+	gerr := &genericError{
 		Timestamp: time.Now(),
 		Err:       err,
-		Message:   err.Error(),
 		ECode:     c,
 		Stack:     stacktrace.Capture(1),
 	}
+	if err != nil {
+		gerr.Message = err.Error()
+	}
+	return gerr
 }
 
 func newSystemError(err error) Error {
 	if le, ok := err.(Error); ok {
 		return le
 	}
-	return &genericError{
+	gerr := &genericError{
 		Timestamp: time.Now(),
 		Err:       err,
 		ECode:     SystemError,
-		Message:   err.Error(),
 		Stack:     stacktrace.Capture(1),
 	}
+	if err != nil {
+		gerr.Message = err.Error()
+	}
+	return gerr
 }
 
 type genericError struct {

--- a/process.go
+++ b/process.go
@@ -1,6 +1,7 @@
 package libcontainer
 
 import (
+	"fmt"
 	"io"
 	"os"
 )
@@ -46,7 +47,7 @@ type Process struct {
 // Wait releases any resources associated with the Process
 func (p Process) Wait() (*os.ProcessState, error) {
 	if p.ops == nil {
-		return nil, newGenericError(nil, ProcessNotExecuted)
+		return nil, newGenericError(fmt.Errorf("invalid process"), ProcessNotExecuted)
 	}
 	return p.ops.wait()
 }
@@ -54,7 +55,7 @@ func (p Process) Wait() (*os.ProcessState, error) {
 // Pid returns the process ID
 func (p Process) Pid() (int, error) {
 	if p.ops == nil {
-		return -1, newGenericError(nil, ProcessNotExecuted)
+		return -1, newGenericError(fmt.Errorf("invalid process"), ProcessNotExecuted)
 	}
 	return p.ops.pid(), nil
 }
@@ -62,7 +63,7 @@ func (p Process) Pid() (int, error) {
 // Signal sends a signal to the Process.
 func (p Process) Signal(sig os.Signal) error {
 	if p.ops == nil {
-		return newGenericError(nil, ProcessNotExecuted)
+		return newGenericError(fmt.Errorf("invalid process"), ProcessNotExecuted)
 	}
 	return p.ops.signal(sig)
 }


### PR DESCRIPTION
`genericError` constructor should not panic when we pass in nil error, but we should not pass nil error actually. This fixes it.