### PR TITLE
cgroups: use Set instead of Apply in Freeze

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -171,11 +171,16 @@ func (m *Manager) Freeze(state configs.FreezerState) error {
 		return err
 	}
 
+	dir, err := d.path("freezer")
+	if err != nil {
+		return err
+	}
+
 	prevState := m.Cgroups.Freezer
 	m.Cgroups.Freezer = state
 
 	freezer := subsystems["freezer"]
-	err = freezer.Apply(d)
+	err = freezer.Set(dir, m.Cgroups)
 	if err != nil {
 		m.Cgroups.Freezer = prevState
 		return err

--- a/cgroups/fs/freezer.go
+++ b/cgroups/fs/freezer.go
@@ -12,20 +12,13 @@ type FreezerGroup struct {
 }
 
 func (s *FreezerGroup) Apply(d *data) error {
-	switch d.c.Freezer {
-	case configs.Frozen, configs.Thawed:
-		dir, err := d.path("freezer")
-		if err != nil {
-			return err
-		}
+	dir, err := d.join("freezer")
+	if err != nil && !cgroups.IsNotFound(err) {
+		return err
+	}
 
-		if err := s.Set(dir, d.c); err != nil {
-			return err
-		}
-	default:
-		if _, err := d.join("freezer"); err != nil && !cgroups.IsNotFound(err) {
-			return err
-		}
+	if err := s.Set(dir, d.c); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
So Apply function of freezer can be as sample as other subsystems.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>