### PR TITLE
Add the file close operation before function return to release resource

### DIFF
--- a/notify_linux.go
+++ b/notify_linux.go
@@ -26,6 +26,7 @@ func notifyOnOOM(paths map[string]string) (<-chan struct{}, error) {
 	}
 	fd, _, syserr := syscall.RawSyscall(syscall.SYS_EVENTFD2, 0, syscall.FD_CLOEXEC, 0)
 	if syserr != 0 {
+		oomControl.Close()
 		return nil, syserr
 	}
 


### PR DESCRIPTION
In function notifyOnOOM,it do the open file operations but do not be close before return,so close file operations should be added to release resource.