### PR TITLE
fix apply error when we not mount cpu subsystem

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -54,12 +54,10 @@ func getCgroupRoot() (string, error) {
 		return cgroupRoot, nil
 	}
 
-	// we can pick any subsystem to find the root
-	cpuRoot, err := cgroups.FindCgroupMountpoint("cpu")
+	root, err := cgroups.FindCgroupMountpointDir()
 	if err != nil {
 		return "", err
 	}
-	root := filepath.Dir(cpuRoot)
 
 	if _, err := os.Stat(root); err != nil {
 		return "", err

--- a/cgroups/utils.go
+++ b/cgroups/utils.go
@@ -34,6 +34,21 @@ func FindCgroupMountpoint(subsystem string) (string, error) {
 	return "", NewNotFoundError(subsystem)
 }
 
+func FindCgroupMountpointDir() (string, error) {
+	mounts, err := mount.GetMounts()
+	if err != nil {
+		return "", err
+	}
+
+	for _, mount := range mounts {
+		if mount.Fstype == "cgroup" {
+			return filepath.Dir(mount.Mountpoint), nil
+		}
+	}
+
+	return "", NewNotFoundError("cgroup")
+}
+
 type Mount struct {
 	Mountpoint string
 	Subsystems []string


### PR DESCRIPTION
Find cgroup mountpoint dir through a specific subsystem is not reliable,
we don't know which subsystem users will or will not mount, we can't
assume that, only we can assume is that users mount cgroup subsystems
on the same dir.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>