### PR TITLE
use real cgroup files for cgroup tests

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -231,6 +231,12 @@ func (raw *data) parent(subsystem string) (string, error) {
 }
 
 func (raw *data) path(subsystem string) (string, error) {
+	_, err := cgroups.FindCgroupMountpoint(subsystem)
+	// If we didn't mount the subsystem, there is no point we make the path.
+	if err != nil {
+		return "", err
+	}
+
 	// If the cgroup name/path is absolute do not look relative to the cgroup of the init process.
 	if filepath.IsAbs(raw.cgroup) {
 		path := filepath.Join(raw.root, subsystem, raw.cgroup)

--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -243,7 +243,7 @@ func (raw *data) path(subsystem string) (string, error) {
 
 		if _, err := os.Stat(path); err != nil {
 			if os.IsNotExist(err) {
-				return "", cgroups.NewNotFoundError(subsystem)
+				return path, cgroups.NewNotFoundError(subsystem)
 			}
 
 			return "", err

--- a/cgroups/fs/blkio.go
+++ b/cgroups/fs/blkio.go
@@ -17,8 +17,12 @@ type BlkioGroup struct {
 
 func (s *BlkioGroup) Apply(d *data) error {
 	dir, err := d.join("blkio")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/blkio_test.go
+++ b/cgroups/fs/blkio_test.go
@@ -74,8 +74,8 @@ func appendBlkioStatEntry(blkioStatEntries *[]cgroups.BlkioStatEntry, major, min
 }
 
 func TestBlkioSetWeight(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 
 	const (
 		weightBefore = 100
@@ -103,8 +103,8 @@ func TestBlkioSetWeight(t *testing.T) {
 }
 
 func TestBlkioStats(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -169,8 +169,8 @@ func TestBlkioStats(t *testing.T) {
 }
 
 func TestBlkioStatsNoSectorsFile(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -190,8 +190,8 @@ func TestBlkioStatsNoSectorsFile(t *testing.T) {
 }
 
 func TestBlkioStatsNoServiceBytesFile(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_serviced_recursive":     servicedRecursiveContents,
 		"blkio.io_queued_recursive":       queuedRecursiveContents,
@@ -211,8 +211,8 @@ func TestBlkioStatsNoServiceBytesFile(t *testing.T) {
 }
 
 func TestBlkioStatsNoServicedFile(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_queued_recursive":        queuedRecursiveContents,
@@ -232,8 +232,8 @@ func TestBlkioStatsNoServicedFile(t *testing.T) {
 }
 
 func TestBlkioStatsNoQueuedFile(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -256,8 +256,8 @@ func TestBlkioStatsNoServiceTimeFile(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -280,8 +280,8 @@ func TestBlkioStatsNoWaitTimeFile(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -304,8 +304,8 @@ func TestBlkioStatsNoMergedFile(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -328,8 +328,8 @@ func TestBlkioStatsNoTimeFile(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": serviceBytesRecursiveContents,
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -349,8 +349,8 @@ func TestBlkioStatsNoTimeFile(t *testing.T) {
 }
 
 func TestBlkioStatsUnexpectedNumberOfFields(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": "8:0 Read 100 100",
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -371,8 +371,8 @@ func TestBlkioStatsUnexpectedNumberOfFields(t *testing.T) {
 }
 
 func TestBlkioStatsUnexpectedFieldType(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": "8:0 Read Write",
 		"blkio.io_serviced_recursive":      servicedRecursiveContents,
@@ -393,8 +393,8 @@ func TestBlkioStatsUnexpectedFieldType(t *testing.T) {
 }
 
 func TestNonCFQBlkioStats(t *testing.T) {
-	helper := NewCgroupTestUtil("blkio", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("blkio", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"blkio.io_service_bytes_recursive": "",
 		"blkio.io_serviced_recursive":      "",

--- a/cgroups/fs/cpu.go
+++ b/cgroups/fs/cpu.go
@@ -18,7 +18,11 @@ func (s *CpuGroup) Apply(d *data) error {
 	// on a container basis
 	dir, err := d.join("cpu")
 	if err != nil {
-		return err
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/cpu_test.go
+++ b/cgroups/fs/cpu_test.go
@@ -78,8 +78,8 @@ func TestCpuSetBandWidth(t *testing.T) {
 }
 
 func TestCpuStats(t *testing.T) {
-	helper := NewCgroupTestUtil("cpu", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("cpu", t)
+	defer helper.tempCleanup()
 
 	const (
 		kNrPeriods     = 2000
@@ -109,8 +109,8 @@ func TestCpuStats(t *testing.T) {
 }
 
 func TestNoCpuStatFile(t *testing.T) {
-	helper := NewCgroupTestUtil("cpu", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("cpu", t)
+	defer helper.tempCleanup()
 
 	cpu := &CpuGroup{}
 	actualStats := *cgroups.NewStats()
@@ -121,8 +121,8 @@ func TestNoCpuStatFile(t *testing.T) {
 }
 
 func TestInvalidCpuStat(t *testing.T) {
-	helper := NewCgroupTestUtil("cpu", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("cpu", t)
+	defer helper.tempCleanup()
 	cpuStatContent := `nr_periods 2000
 	nr_throttled 200
 	throttled_time fortytwo`

--- a/cgroups/fs/cpuset.go
+++ b/cgroups/fs/cpuset.go
@@ -17,7 +17,11 @@ type CpusetGroup struct {
 func (s *CpusetGroup) Apply(d *data) error {
 	dir, err := d.path("cpuset")
 	if err != nil {
-		return err
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 	return s.ApplyDir(dir, d.c, d.pid)
 }

--- a/cgroups/fs/devices.go
+++ b/cgroups/fs/devices.go
@@ -11,7 +11,11 @@ type DevicesGroup struct {
 func (s *DevicesGroup) Apply(d *data) error {
 	dir, err := d.join("devices")
 	if err != nil {
-		return err
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/devices_test.go
+++ b/cgroups/fs/devices_test.go
@@ -25,7 +25,7 @@ func TestDevicesSetAllow(t *testing.T) {
 	defer helper.cleanup()
 
 	helper.writeFileContents(map[string]string{
-		"device.deny": "a",
+		"devices.deny": "a",
 	})
 
 	helper.CgroupData.c.AllowAllDevices = false
@@ -35,9 +35,7 @@ func TestDevicesSetAllow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// FIXME: this doesn't make sence, the file devices.allow under real cgroupfs
-	// is not allowed to read. Our test path don't have cgroupfs mounted.
-	value, err := getCgroupParamString(helper.CgroupPath, "devices.allow")
+	value, err := getCgroupParamString(helper.CgroupPath, "devices.list")
 	if err != nil {
 		t.Fatalf("Failed to parse devices.allow - %s", err)
 	}

--- a/cgroups/fs/freezer.go
+++ b/cgroups/fs/freezer.go
@@ -13,8 +13,12 @@ type FreezerGroup struct {
 
 func (s *FreezerGroup) Apply(d *data) error {
 	dir, err := d.join("freezer")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -16,9 +16,12 @@ type MemoryGroup struct {
 
 func (s *MemoryGroup) Apply(d *data) error {
 	dir, err := d.join("memory")
-	// only return an error for memory if it was specified
-	if err != nil && (d.c.Memory != 0 || d.c.MemoryReservation != 0 || d.c.MemorySwap != 0) {
-		return err
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 	defer func() {
 		if err != nil {

--- a/cgroups/fs/memory_test.go
+++ b/cgroups/fs/memory_test.go
@@ -33,6 +33,7 @@ func TestMemorySetMemory(t *testing.T) {
 
 	helper.CgroupData.c.Memory = memoryAfter
 	helper.CgroupData.c.MemoryReservation = reservationAfter
+	helper.CgroupData.c.MemorySwap = -1
 	memory := &MemoryGroup{}
 	if err := memory.Set(helper.CgroupPath, helper.CgroupData.c); err != nil {
 		t.Fatal(err)

--- a/cgroups/fs/memory_test.go
+++ b/cgroups/fs/memory_test.go
@@ -57,8 +57,8 @@ func TestMemorySetMemory(t *testing.T) {
 }
 
 func TestMemoryStats(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("memory", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     memoryUsageContents,
@@ -77,8 +77,8 @@ func TestMemoryStats(t *testing.T) {
 }
 
 func TestMemoryStatsNoStatFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("memory", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.usage_in_bytes":     memoryUsageContents,
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
@@ -93,8 +93,8 @@ func TestMemoryStatsNoStatFile(t *testing.T) {
 }
 
 func TestMemoryStatsNoUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("memory", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.max_usage_in_bytes": memoryMaxUsageContents,
@@ -109,8 +109,8 @@ func TestMemoryStatsNoUsageFile(t *testing.T) {
 }
 
 func TestMemoryStatsNoMaxUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("memory", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":           memoryStatContents,
 		"memory.usage_in_bytes": memoryUsageContents,
@@ -125,8 +125,8 @@ func TestMemoryStatsNoMaxUsageFile(t *testing.T) {
 }
 
 func TestMemoryStatsBadStatFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("memory", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               "rss rss",
 		"memory.usage_in_bytes":     memoryUsageContents,
@@ -142,8 +142,8 @@ func TestMemoryStatsBadStatFile(t *testing.T) {
 }
 
 func TestMemoryStatsBadUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("memory", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     "bad",
@@ -159,8 +159,8 @@ func TestMemoryStatsBadUsageFile(t *testing.T) {
 }
 
 func TestMemoryStatsBadMaxUsageFile(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
+	helper := tempCgroupTestUtil("memory", t)
+	defer helper.tempCleanup()
 	helper.writeFileContents(map[string]string{
 		"memory.stat":               memoryStatContents,
 		"memory.usage_in_bytes":     memoryUsageContents,


### PR DESCRIPTION
Right now, we test cgroup features and apis with normal files, not cgroup files managed by cgroupfs, that is not reasonable.

One problem is that stats tests write a lot of files which are not allowed to be written in cgroup files, these can't be changed easily, we need to figure out a better way to test stats.