### PR TITLE
fix some cgroups issues

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -229,6 +229,12 @@ func (raw *data) parent(subsystem string) (string, error) {
 }
 
 func (raw *data) path(subsystem string) (string, error) {
+	_, err := cgroups.FindCgroupMountpoint(subsystem)
+	// If we didn't mount the subsystem, there is no point we make the path.
+	if err != nil {
+		return "", err
+	}
+
 	// If the cgroup name/path is absolute do not look relative to the cgroup of the init process.
 	if filepath.IsAbs(raw.cgroup) {
 		path := filepath.Join(raw.root, subsystem, raw.cgroup)

--- a/cgroups/fs/blkio.go
+++ b/cgroups/fs/blkio.go
@@ -17,8 +17,12 @@ type BlkioGroup struct {
 
 func (s *BlkioGroup) Apply(d *data) error {
 	dir, err := d.join("blkio")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/cpu.go
+++ b/cgroups/fs/cpu.go
@@ -18,7 +18,11 @@ func (s *CpuGroup) Apply(d *data) error {
 	// on a container basis
 	dir, err := d.join("cpu")
 	if err != nil {
-		return err
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/cpuset.go
+++ b/cgroups/fs/cpuset.go
@@ -17,7 +17,11 @@ type CpusetGroup struct {
 func (s *CpusetGroup) Apply(d *data) error {
 	dir, err := d.path("cpuset")
 	if err != nil {
-		return err
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 	return s.ApplyDir(dir, d.c, d.pid)
 }

--- a/cgroups/fs/devices.go
+++ b/cgroups/fs/devices.go
@@ -11,7 +11,11 @@ type DevicesGroup struct {
 func (s *DevicesGroup) Apply(d *data) error {
 	dir, err := d.join("devices")
 	if err != nil {
-		return err
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/devices_test.go
+++ b/cgroups/fs/devices_test.go
@@ -25,7 +25,7 @@ func TestDevicesSetAllow(t *testing.T) {
 	defer helper.cleanup()
 
 	helper.writeFileContents(map[string]string{
-		"device.deny": "a",
+		"devices.deny": "a",
 	})
 
 	helper.CgroupData.c.AllowAllDevices = false
@@ -35,8 +35,6 @@ func TestDevicesSetAllow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// FIXME: this doesn't make sence, the file devices.allow under real cgroupfs
-	// is not allowed to read. Our test path don't have cgroupfs mounted.
 	value, err := getCgroupParamString(helper.CgroupPath, "devices.allow")
 	if err != nil {
 		t.Fatalf("Failed to parse devices.allow - %s", err)

--- a/cgroups/fs/freezer.go
+++ b/cgroups/fs/freezer.go
@@ -13,8 +13,12 @@ type FreezerGroup struct {
 
 func (s *FreezerGroup) Apply(d *data) error {
 	dir, err := d.join("freezer")
-	if err != nil && !cgroups.IsNotFound(err) {
-		return err
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -16,9 +16,12 @@ type MemoryGroup struct {
 
 func (s *MemoryGroup) Apply(d *data) error {
 	dir, err := d.join("memory")
-	// only return an error for memory if it was specified
-	if err != nil && (d.c.Memory != 0 || d.c.MemoryReservation != 0 || d.c.MemorySwap != 0) {
-		return err
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		} else {
+			return err
+		}
 	}
 	defer func() {
 		if err != nil {

--- a/cgroups/fs/util_test.go
+++ b/cgroups/fs/util_test.go
@@ -6,9 +6,9 @@ Creates a mock of the cgroup filesystem for the duration of the test.
 package fs
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/docker/libcontainer/configs"
@@ -31,12 +31,12 @@ func NewCgroupTestUtil(subsystem string, t *testing.T) *cgroupTestUtil {
 	d := &data{
 		c: &configs.Cgroup{},
 	}
-	tempDir, err := ioutil.TempDir("", fmt.Sprintf("%s_cgroup_test", subsystem))
+	tempDir, err := ioutil.TempDir("", "cgroup_test")
 	if err != nil {
 		t.Fatal(err)
 	}
 	d.root = tempDir
-	testCgroupPath, err := d.path(subsystem)
+	testCgroupPath := filepath.Join(d.root, subsystem)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
1. add subsystem mounted check in `d.path()`, so we can really get `IsNotFound` error and skip `Set`.
2. cgroup unit test use temp path, not real cgroup path, so we should create the path by `filepath.Join()` instead of `d.path()`.