### PR TITLE
nsenter: fix the -Wunused-variable warning

### DIFF
--- a/nsenter/nsenter.go
+++ b/nsenter/nsenter.go
@@ -1,25 +1,12 @@
-// +build linux
+// +build linux,!gccgo
 
 package nsenter
 
 /*
 #cgo CFLAGS: -Wall
 extern void nsexec();
-void __attribute__((constructor)) init() {
+void __attribute__((constructor)) init(void) {
 	nsexec();
 }
 */
 import "C"
-
-// AlwaysFalse is here to stay false
-// (and be exported so the compiler doesn't optimize out its reference)
-var AlwaysFalse bool
-
-func init() {
-	if AlwaysFalse {
-		// by referencing this C init() in a noop test, it will ensure the compiler
-		// links in the C function.
-		// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65134
-		C.init()
-	}
-}

--- a/nsenter/nsenter_gccgo.go
+++ b/nsenter/nsenter_gccgo.go
@@ -1,0 +1,25 @@
+// +build linux,gccgo
+
+package nsenter
+
+/*
+#cgo CFLAGS: -Wall
+extern void nsexec();
+void __attribute__((constructor)) init(void) {
+	nsexec();
+}
+*/
+import "C"
+
+// AlwaysFalse is here to stay false
+// (and be exported so the compiler doesn't optimize out its reference)
+var AlwaysFalse bool
+
+func init() {
+	if AlwaysFalse {
+		// by referencing this C init() in a noop test, it will ensure the compiler
+		// links in the C function.
+		// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65134
+		C.init()
+	}
+}


### PR DESCRIPTION
The change 699429e60f23ab0fa3bdd97b6326316be08791ad that allows the
constructor attribute to not be optimized out on gccgo has resulted in a
warning when compiling on the golang compiler.

```
./nsenter.go: In function ‘_cgo_51505a0edd5d_Cfunc_init’:
./nsenter.go:40:49: warning: unused variable ‘a’ [-Wunused-variable]
```

the generated code produced an unused struct like:

```
void
_cgo_d6cfae95ae01_Cfunc_init (void *v)
{
  struct
  {
    char unused;
  } __attribute__ ((__packed__, __gcc_struct__)) * a = v;
  init ();
}
```

Truly the "fix" would be upstream in cgo. If it knows it is producing an
unused struct, then it should also include __attribute__ ((unused))

Signed-off-by: Vincent Batts <vbatts@hashbangbash.com>