### PR TITLE
add parameter to Set api

### DIFF
--- a/container.go
+++ b/container.go
@@ -96,7 +96,7 @@ type Container interface {
 	//
 	// errors:
 	// Systemerror - System error.
-	Set() error
+	Set(config configs.Config) error
 
 	// Start a process inside the container. Returns error if process fails to
 	// start. You can track process lifecycle with passed Process structure.

--- a/container_linux.go
+++ b/container_linux.go
@@ -78,9 +78,10 @@ func (c *linuxContainer) Stats() (*Stats, error) {
 	return stats, nil
 }
 
-func (c *linuxContainer) Set() error {
+func (c *linuxContainer) Set(config configs.Config) error {
 	c.m.Lock()
 	defer c.m.Unlock()
+	c.config = &config
 	return c.cgroupManager.Set(c.config)
 }
 


### PR DESCRIPTION
We only have libcontainer.Container on Docker side, can't change `config`
in linuxContainer, pass config to libcontainer so we can change config of
container.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>