### PR TITLE
Don't label mqueue when mounting

### DIFF
--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -104,6 +104,10 @@ func mount(m *configs.Mount, rootfs, mountLabel string) error {
 		if err := os.MkdirAll(dest, 0755); err != nil && !os.IsExist(err) {
 			return err
 		}
+		if m.Device == "mqueue" {
+			// mqueue should not be labeled, otherwise the mount will fail
+			data = ""
+		}
 		return syscall.Mount(m.Source, dest, m.Device, uintptr(m.Flags), data)
 	case "bind":
 		stat, err := os.Stat(m.Source)


### PR DESCRIPTION
mqueue shouldn't be labeled when mounting; otherwise, the mount will
fail.

Signed-off-by: Andy Goldstein <agoldste@redhat.com>