### PR TITLE
Add information Type method for Factory

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -41,4 +41,7 @@ type Factory interface {
 	// pipe connection error
 	// system error
 	StartInitialization(pipefd uintptr) error
+
+	// Type returns info string about factory type (e.g. lxc, libcontainer...)
+	Type() string
 }

--- a/factory_linux.go
+++ b/factory_linux.go
@@ -172,6 +172,10 @@ func (l *LinuxFactory) Load(id string) (Container, error) {
 	}, nil
 }
 
+func (l *LinuxFactory) Type() string {
+	return "libcontainer"
+}
+
 // StartInitialization loads a container by opening the pipe fd from the parent to read the configuration and state
 // This is a low level implementation detail of the reexec and should not be consumed externally
 func (l *LinuxFactory) StartInitialization(pipefd uintptr) (err error) {

--- a/factory_linux_test.go
+++ b/factory_linux_test.go
@@ -43,6 +43,10 @@ func TestFactoryNew(t *testing.T) {
 	if lfactory.Root != root {
 		t.Fatalf("expected factory root to be %q but received %q", root, lfactory.Root)
 	}
+
+	if factory.Type() != "libcontainer" {
+		t.Fatalf("unexpected factory type: %q, expected %q", factory.Type(), "libcontainer")
+	}
 }
 
 func TestFactoryLoadNotExists(t *testing.T) {


### PR DESCRIPTION
I need this for `docker info` don't want to use type assertions because actually `LinuxFactory` should be private.