### PR TITLE
Hairpin NAT network configuration

### DIFF
--- a/configs/network.go
+++ b/configs/network.go
@@ -42,6 +42,12 @@ type Network struct {
 	// HostInterfaceName is a unique name of a veth pair that resides on in the host interface of the
 	// container.
 	HostInterfaceName string `json:"host_interface_name"`
+
+	// HairpinMode specifies if hairpin NAT should be enabled on the virtual interface
+	// bridge port in the case of type veth
+	// Note: This is unsupported on some systems.
+	// Note: This does not apply to loopback interfaces.
+	HairpinMode bool `json:"hairpin_mode"`
 }
 
 // Routes can be specified to create entries in the route table as the container is started

--- a/network_linux.go
+++ b/network_linux.go
@@ -135,6 +135,11 @@ func (v *veth) create(n *network, nspid int) (err error) {
 	if err := netlink.NetworkSetMTU(host, n.Mtu); err != nil {
 		return err
 	}
+	if n.HairpinMode {
+		if err := netlink.SetHairpinMode(host, true); err != nil {
+			return err
+		}
+	}
 	if err := netlink.NetworkLinkUp(host); err != nil {
 		return err
 	}


### PR DESCRIPTION
Resurrect #366 which was apparently lost in the API rework.