### PR TITLE
Update to recent busybox 2014.11 tar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go get github.com/docker/docker/pkg/term
 
 # setup a playground for us to spawn containers in
 RUN mkdir /busybox && \
-    curl -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.02/rootfs.tar' | tar -xC /busybox
+    curl -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.11/rootfs.tar' | tar -xC /busybox
 
 RUN curl -sSL https://raw.githubusercontent.com/docker/docker/master/project/dind -o /dind && \
     chmod +x /dind


### PR DESCRIPTION
Move up to the latest busybox tarball that has the fix for `ip` command
segfault.

Docker-DCO-1.1-Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)