### PR TITLE
Fix path to /dind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN go get github.com/docker/docker/pkg/term
 RUN mkdir /busybox && \
     curl -sSL 'https://github.com/jpetazzo/docker-busybox/raw/buildroot-2014.11/rootfs.tar' | tar -xC /busybox
 
-RUN curl -sSL https://raw.githubusercontent.com/docker/docker/master/project/dind -o /dind && \
+RUN curl -sSL https://raw.githubusercontent.com/docker/docker/master/hack/dind -o /dind && \
     chmod +x /dind
 
 COPY . /go/src/github.com/docker/libcontainer


### PR DESCRIPTION
That script was moved a few days ago
https://github.com/docker/docker/pull/11373

Signed-off-by: Andrew Vagin <avagin@openvz.org>