### PR TITLE
mount: sysfs also doesn't need to be labelled like mqueue.

### DIFF
--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -95,7 +95,7 @@ func mount(m *configs.Mount, rootfs, mountLabel string) error {
 	}
 
 	switch m.Device {
-	case "proc":
+	case "proc", "mqueue", "sysfs":
 		if err := os.MkdirAll(dest, 0755); err != nil && !os.IsExist(err) {
 			return err
 		}
@@ -116,13 +116,9 @@ func mount(m *configs.Mount, rootfs, mountLabel string) error {
 			}
 		}
 		return nil
-	case "mqueue", "devpts", "sysfs":
+	case "devpts":
 		if err := os.MkdirAll(dest, 0755); err != nil && !os.IsExist(err) {
 			return err
-		}
-		if m.Device == "mqueue" {
-			// mqueue should not be labeled, otherwise the mount will fail
-			data = ""
 		}
 		return syscall.Mount(m.Source, dest, m.Device, uintptr(m.Flags), data)
 	case "bind":


### PR DESCRIPTION
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>