### PR TITLE
Do not fail cgroups setup if parent cgroup does not exist.

### DIFF
--- a/cgroups/fs/cpuset.go
+++ b/cgroups/fs/cpuset.go
@@ -17,12 +17,9 @@ type CpusetGroup struct {
 func (s *CpusetGroup) Apply(d *data) error {
 	dir, err := d.path("cpuset")
 	if err != nil {
-		if cgroups.IsNotFound(err) {
-			return nil
-		} else {
-			return err
-		}
+		return err
 	}
+
 	return s.ApplyDir(dir, d.c, d.pid)
 }
 


### PR DESCRIPTION
As of now if the parent cgroup path is absolute, we expect the cgroups to exist. If it is not absolute, everything works as expected.