### PR TITLE
Add `Cleanup()` to Factory interface

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -44,4 +44,7 @@ type Factory interface {
 
 	// Type returns info string about factory type (e.g. lxc, libcontainer...)
 	Type() string
+
+	// Cleanup releases all resources used by the factory
+	Cleanup() error
 }

--- a/factory_linux.go
+++ b/factory_linux.go
@@ -192,6 +192,18 @@ func (l *LinuxFactory) Type() string {
 	return "libcontainer"
 }
 
+func (l *LinuxFactory) Cleanup() error {
+	mounted, err := mount.Mounted(l.Root)
+	if err != nil {
+		return err
+	}
+	if !mounted {
+		return nil
+	}
+
+	return syscall.Unmount(l.Root, 0)
+}
+
 // StartInitialization loads a container by opening the pipe fd from the parent to read the configuration and state
 // This is a low level implementation detail of the reexec and should not be consumed externally
 func (l *LinuxFactory) StartInitialization(pipefd uintptr) (err error) {

--- a/factory_linux_test.go
+++ b/factory_linux_test.go
@@ -97,6 +97,17 @@ func TestFactoryNewTmpfs(t *testing.T) {
 	if !found {
 		t.Fatalf("Factory Root is not listed in mounts list")
 	}
+
+	if err := lfactory.Cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	mounted, err = mount.Mounted(lfactory.Root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mounted {
+		t.Fatalf("expected factory root to be unmounted after cleanup")
+	}
 }
 
 func TestFactoryLoadNotExists(t *testing.T) {


### PR DESCRIPTION
Cleanup releases all resources held by the given factory.
In the case of the LinuxFactory it cleans up the `tmpfs` mount.
