### PR TITLE
Destroy method for Factory

### DIFF
--- a/error.go
+++ b/error.go
@@ -10,6 +10,7 @@ const (
 	// Factory errors
 	IdInUse ErrorCode = iota
 	InvalidIdFormat
+	RootIsNotEmpty
 
 	// Container errors
 	ContainerNotExists
@@ -31,6 +32,8 @@ func (c ErrorCode) String() string {
 		return "Id already in use"
 	case InvalidIdFormat:
 		return "Invalid format"
+	case RootIsNotEmpty:
+		return "Factory root is not empty"
 	case ContainerPaused:
 		return "Container paused"
 	case ConfigInvalid:

--- a/factory.go
+++ b/factory.go
@@ -44,4 +44,9 @@ type Factory interface {
 
 	// Type returns info string about factory type (e.g. lxc, libcontainer...)
 	Type() string
+
+	// Destroy just brutally removes factory root.
+	// errors:
+	// Root is not empty
+	Destroy() error
 }

--- a/factory_linux.go
+++ b/factory_linux.go
@@ -192,6 +192,18 @@ func (l *LinuxFactory) Type() string {
 	return "libcontainer"
 }
 
+func (l *LinuxFactory) Destroy() error {
+	ls, err := ioutil.ReadDir(l.Root)
+	if err != nil {
+		return newGenericError(err, SystemError)
+	}
+	if len(ls) != 0 {
+		return newGenericError(fmt.Errorf("%s is not empty", l.Root), RootIsNotEmpty)
+	}
+	syscall.Unmount(l.Root, syscall.MNT_DETACH)
+	return os.Remove(l.Root)
+}
+
 // StartInitialization loads a container by opening the pipe fd from the parent to read the configuration and state
 // This is a low level implementation detail of the reexec and should not be consumed externally
 func (l *LinuxFactory) StartInitialization(pipefd uintptr) (err error) {


### PR DESCRIPTION
We probably need this, because now we have mounted dir after docker stops.