### PR TITLE
Throw an error if cgroup tries to set cpu-shares more/less than the maximum/minimum permissible value.

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -1,8 +1,11 @@
 package fs
 
 import (
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -75,9 +78,12 @@ type data struct {
 }
 
 func (m *Manager) Apply(pid int) error {
+
 	if m.Cgroups == nil {
 		return nil
 	}
+
+	var c = m.Cgroups
 
 	d, err := getCgroupData(m.Cgroups, pid)
 	if err != nil {
@@ -107,6 +113,28 @@ func (m *Manager) Apply(pid int) error {
 		paths[name] = p
 	}
 	m.Paths = paths
+
+	var cpuShares int64
+
+	fd, err := os.Open(path.Join(m.Paths["cpu"], "cpu.shares"))
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fscanf(fd, "%d", &cpuShares)
+	if err != nil && err != io.EOF {
+		return err
+	}
+
+	fd.Close()
+
+	if c.CpuShares != 0 {
+		if c.CpuShares > cpuShares {
+			return fmt.Errorf("The maximum allowed cpu-shares is %d", cpuShares)
+		} else if c.CpuShares < cpuShares {
+			return fmt.Errorf("The minimum allowed cpu-shares is %d", cpuShares)
+		}
+	}
 
 	return nil
 }

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -5,8 +5,10 @@ package systemd
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -240,6 +242,28 @@ func (m *Manager) Apply(pid int) error {
 	}
 
 	m.Paths = paths
+
+	var cpuShares int64
+
+	fd, err := os.Open(path.Join(m.Paths["cpu"], "cpu.shares"))
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fscanf(fd, "%d", &cpuShares)
+	if err != nil && err != io.EOF {
+		return err
+	}
+
+	fd.Close()
+
+	if c.CpuShares != 0 {
+		if c.CpuShares > cpuShares {
+			return fmt.Errorf("The maximum allowed cpu-shares is %d", cpuShares)
+		} else if c.CpuShares < cpuShares {
+			return fmt.Errorf("The minimum allowed cpu-shares is %d", cpuShares)
+		}
+	}
 
 	return nil
 }


### PR DESCRIPTION
If I pass a value for `cpu-shares` larger than the maximum allowed value, the kernel just changes it to the maximum allowed value. This is confusing for the user as what he requested and what is set is different.

e.g. if the max possible value is 262144 and I tried to set cpu-shares as 280000, 
This code will throw an application error saying "The maximum allowed cpu-shares is 262144".



