### PR TITLE
systemd: properly check DefaultDependencies is read only

### DIFF
--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -91,7 +91,7 @@ func UseSystemd() bool {
 		ddf := newProp("DefaultDependencies", false)
 		if _, err := theConn.StartTransientUnit("docker-systemd-test-default-dependencies.scope", "replace", ddf); err != nil {
 			if dbusError, ok := err.(dbus.Error); ok {
-				if dbusError.Name == "org.freedesktop.DBus.Error.PropertyReadOnly" {
+				if strings.Contains(dbusError.Name, "org.freedesktop.DBus.Error.PropertyReadOnly") {
 					hasTransientDefaultDependencies = false
 				}
 			}


### PR DESCRIPTION
on systemd v208 in Centos7 and Fedora20 error is not:
"org.freedesktop.DBus.Error.PropertyReadOnly"
but:
"property.org.freedesktop.DBus.Error.PropertyReadOnly"
so check failes and in Docker we get:
Docker daemon: System error: Cannot set property DefaultDependencies, or
unknown property

Fix for commit:
https://github.com/docker/libcontainer/commit/99233fde8c4f58853a474a5831ef0bcf6bf866c5

Signed-off-by: Pavel Tikhomirov <ptikhomirov@parallels.com>