### PR TITLE
path now returns the IsNotFound error

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -99,12 +99,11 @@ func (m *Manager) Apply(pid int) error {
 		// created then join consists of writing the process pids to cgroup.procs
 		p, err := d.path(name)
 		if err != nil {
+			if cgroups.IsNotFound(err) {
+				continue
+			}
 			return err
 		}
-		if !cgroups.PathExists(p) {
-			continue
-		}
-
 		paths[name] = p
 	}
 	m.Paths = paths


### PR DESCRIPTION
This error is not propogated up to the caller and needs to be handled at
the site where d.path() is called.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>