### PR TITLE
Devices cgroup is required for security reasons

### DIFF
--- a/cgroups/fs/devices.go
+++ b/cgroups/fs/devices.go
@@ -11,18 +11,9 @@ type DevicesGroup struct {
 func (s *DevicesGroup) Apply(d *data) error {
 	dir, err := d.join("devices")
 	if err != nil {
-		if cgroups.IsNotFound(err) {
-			return nil
-		} else {
-			return err
-		}
-	}
-
-	if err := s.Set(dir, d.c); err != nil {
 		return err
 	}
-
-	return nil
+	return s.Set(dir, d.c)
 }
 
 func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {


### PR DESCRIPTION
Signed-off-by: Michael Crosby <crosbymichael@gmail.com>