### PR TITLE
Revert "cgroups: only return path when subsystem really mounted

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -235,6 +235,12 @@ func (raw *data) parent(subsystem string) (string, error) {
 }
 
 func (raw *data) path(subsystem string) (string, error) {
+	_, err := cgroups.FindCgroupMountpoint(subsystem)
+	// If we didn't mount the subsystem, there is no point we make the path.
+	if err != nil {
+		return "", err
+	}
+
 	// If the cgroup name/path is absolute do not look relative to the cgroup of the init process.
 	if filepath.IsAbs(raw.cgroup) {
 		return filepath.Join(raw.root, subsystem, raw.cgroup), nil

--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -235,12 +235,6 @@ func (raw *data) parent(subsystem string) (string, error) {
 }
 
 func (raw *data) path(subsystem string) (string, error) {
-	_, err := cgroups.FindCgroupMountpoint(subsystem)
-	// If we didn't mount the subsystem, there is no point we make the path.
-	if err != nil {
-		return "", err
-	}
-
 	// If the cgroup name/path is absolute do not look relative to the cgroup of the init process.
 	if filepath.IsAbs(raw.cgroup) {
 		return filepath.Join(raw.root, subsystem, raw.cgroup), nil

--- a/cgroups/fs/blkio.go
+++ b/cgroups/fs/blkio.go
@@ -17,12 +17,8 @@ type BlkioGroup struct {
 
 func (s *BlkioGroup) Apply(d *data) error {
 	dir, err := d.join("blkio")
-	if err != nil {
-		if cgroups.IsNotFound(err) {
-			return nil
-		} else {
-			return err
-		}
+	if err != nil && !cgroups.IsNotFound(err) {
+		return err
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/cpu.go
+++ b/cgroups/fs/cpu.go
@@ -18,11 +18,7 @@ func (s *CpuGroup) Apply(d *data) error {
 	// on a container basis
 	dir, err := d.join("cpu")
 	if err != nil {
-		if cgroups.IsNotFound(err) {
-			return nil
-		} else {
-			return err
-		}
+		return err
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/devices.go
+++ b/cgroups/fs/devices.go
@@ -11,11 +11,7 @@ type DevicesGroup struct {
 func (s *DevicesGroup) Apply(d *data) error {
 	dir, err := d.join("devices")
 	if err != nil {
-		if cgroups.IsNotFound(err) {
-			return nil
-		} else {
-			return err
-		}
+		return err
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/freezer.go
+++ b/cgroups/fs/freezer.go
@@ -13,12 +13,8 @@ type FreezerGroup struct {
 
 func (s *FreezerGroup) Apply(d *data) error {
 	dir, err := d.join("freezer")
-	if err != nil {
-		if cgroups.IsNotFound(err) {
-			return nil
-		} else {
-			return err
-		}
+	if err != nil && !cgroups.IsNotFound(err) {
+		return err
 	}
 
 	if err := s.Set(dir, d.c); err != nil {

--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -16,12 +16,9 @@ type MemoryGroup struct {
 
 func (s *MemoryGroup) Apply(d *data) error {
 	dir, err := d.join("memory")
-	if err != nil {
-		if cgroups.IsNotFound(err) {
-			return nil
-		} else {
-			return err
-		}
+	// only return an error for memory if it was specified
+	if err != nil && (d.c.Memory != 0 || d.c.MemoryReservation != 0 || d.c.MemorySwap != 0) {
+		return err
 	}
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
We need to do this so that when a user specifies an option and we are unable to fulfill the request we should fail hard instead of ignoring the error and keep going.  We also need to fail hard for cgroups like `devices` because of security reasons. 