### PR TITLE
remove redundant code

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -173,9 +173,6 @@ func (m *Manager) Freeze(state configs.FreezerState) error {
 	if err != nil {
 		return err
 	}
-	if !cgroups.PathExists(dir) {
-		return cgroups.NewNotFoundError("freezer")
-	}
 
 	prevState := m.Cgroups.Freezer
 	m.Cgroups.Freezer = state
@@ -199,9 +196,6 @@ func (m *Manager) GetPids() ([]int, error) {
 	dir, err := d.path("devices")
 	if err != nil {
 		return nil, err
-	}
-	if !cgroups.PathExists(dir) {
-		return nil, cgroups.NewNotFoundError("devices")
 	}
 
 	return cgroups.ReadProcsFile(dir)


### PR DESCRIPTION
Now we return not found err in path(), so no need to check again.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>