### PR TITLE
systemd may not check DefaultDependencies is read only

### DIFF
--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -91,8 +91,14 @@ func UseSystemd() bool {
 		ddf := newProp("DefaultDependencies", false)
 		if _, err := theConn.StartTransientUnit("docker-systemd-test-default-dependencies.scope", "replace", ddf); err != nil {
 			if dbusError, ok := err.(dbus.Error); ok {
-				if strings.Contains(dbusError.Name, "org.freedesktop.DBus.Error.PropertyReadOnly") {
-					hasTransientDefaultDependencies = false
+				if strings.Contains(dbusError.Name, "org.freedesktop.systemd1.UnitExists") {
+					if err := theConn.SetUnitProperties("docker-systemd-test-default-dependencies.scope", true, ddf); err != nil {
+						if dbusError, ok := err.(dbus.Error); ok {
+							if strings.Contains(dbusError.Name, "org.freedesktop.DBus.Error.PropertyReadOnly") {
+								hasTransientDefaultDependencies = false
+							}
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
On system v208, when systemd unit exist, it may not check
DefaultDependencies is read only, it will return directly.
And this lead that docker container can't start correctly.
And this commit will fix this bug.

Signed-off-by: Chao Chen <chenchao@qiyi.com>