### PR TITLE
Update syndtr/gocapability to 8e4cdcb3c22b40d5e330ade0b68cb2e2a3cf6f98

### DIFF
--- a/update-vendor.sh
+++ b/update-vendor.sh
@@ -44,6 +44,6 @@ clone git github.com/codegangsta/cli 1.1.0
 clone git github.com/coreos/go-systemd v2
 clone git github.com/godbus/dbus v2
 clone git github.com/Sirupsen/logrus v0.6.6
-clone git github.com/syndtr/gocapability e55e583369
+clone git github.com/syndtr/gocapability 8e4cdcb
 
 # intentionally not vendoring Docker itself...  that'd be a circle :)

--- a/vendor/src/github.com/syndtr/gocapability/capability/capability_linux.go
+++ b/vendor/src/github.com/syndtr/gocapability/capability/capability_linux.go
@@ -417,10 +417,6 @@ func (c *capsV3) Load() (err error) {
 }
 
 func (c *capsV3) Apply(kind CapType) (err error) {
-	err = initLastCap()
-	if err != nil {
-		return
-	}
 	if kind&BOUNDS == BOUNDS {
 		var data [2]capData
 		err = capget(&c.hdr, &data[0])
@@ -428,7 +424,7 @@ func (c *capsV3) Apply(kind CapType) (err error) {
 			return
 		}
 		if (1<<uint(CAP_SETPCAP))&data[0].effective != 0 {
-			for i := Cap(0); i <= capLastCap; i++ {
+			for i := Cap(0); i <= CAP_LAST_CAP; i++ {
 				if c.Get(BOUNDING, i) {
 					continue
 				}


### PR DESCRIPTION
It includes fix for RHEL6 which has no cap_last.