### PR TITLE
Process capabilities

### DIFF
--- a/container_linux.go
+++ b/container_linux.go
@@ -193,12 +193,13 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, 
 
 func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
 	return &initConfig{
-		Config:  c.config,
-		Args:    process.Args,
-		Env:     process.Env,
-		User:    process.User,
-		Cwd:     process.Cwd,
-		Console: process.consolePath,
+		Config:       c.config,
+		Args:         process.Args,
+		Env:          process.Env,
+		User:         process.User,
+		Cwd:          process.Cwd,
+		Console:      process.consolePath,
+		Capabilities: process.Capabilities,
 	}
 }
 

--- a/init_linux.go
+++ b/init_linux.go
@@ -40,13 +40,14 @@ type network struct {
 
 // initConfig is used for transferring parameters from Exec() to Init()
 type initConfig struct {
-	Args     []string        `json:"args"`
-	Env      []string        `json:"env"`
-	Cwd      string          `json:"cwd"`
-	User     string          `json:"user"`
-	Config   *configs.Config `json:"config"`
-	Console  string          `json:"console"`
-	Networks []*network      `json:"network"`
+	Args         []string        `json:"args"`
+	Env          []string        `json:"env"`
+	Cwd          string          `json:"cwd"`
+	Capabilities []string        `json:"capabilities"`
+	User         string          `json:"user"`
+	Config       *configs.Config `json:"config"`
+	Console      string          `json:"console"`
+	Networks     []*network      `json:"network"`
 }
 
 type initer interface {
@@ -99,7 +100,12 @@ func finalizeNamespace(config *initConfig) error {
 	if err := utils.CloseExecFrom(3); err != nil {
 		return err
 	}
-	w, err := newCapWhitelist(config.Config.Capabilities)
+
+	capabilities := config.Config.Capabilities
+	if config.Capabilities != nil {
+		capabilities = config.Capabilities
+	}
+	w, err := newCapWhitelist(capabilities)
 	if err != nil {
 		return err
 	}

--- a/process.go
+++ b/process.go
@@ -41,6 +41,10 @@ type Process struct {
 	// consolePath is the path to the console allocated to the container.
 	consolePath string
 
+	// Capabilities specify the capabilities to keep when executing the process inside the container
+	// All capbilities not specified will be dropped from the processes capability mask
+	Capabilities []string
+
 	ops processOperations
 }
 


### PR DESCRIPTION
This allows a process to override the capabilities specified in the container config. This could allow one to run more/less privileged processes in a container. For e.g. to examine logs or modify iptables.

Signed-off-by: Mrunal Patel <mrunalp@gmail.com>