### PR TITLE
add binary target to direct install in a container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+bundles
 nsinit/nsinit

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,5 @@ local:
 validate:
 	hack/validate.sh
 
+binary: all
+	docker run --rm --privileged -v $(CURDIR)/bundles:/go/bin dockercore/libcontainer make direct-install

--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ container.Resume()
 It is able to spawn new containers or join existing containers.  A root
 filesystem must be provided for use along with a container configuration file.
 
+To build `nsinit`, run `make binary`. It will save the binary into
+`bundles/nsinit`.
+
 To use `nsinit`, cd into a Linux rootfs and copy a `container.json` file into 
 the directory with your specified configuration. Environment, networking, 
 and different capabilities for the container are specified in this file. 


### PR DESCRIPTION
This adds `make binary` to perform direct install libcontainer binaries inside `dockercore/libcontainer` container instead of having to install dependencies and run `make direct-install` on the host.

The `nsinit` binary will be placed into `bundles/nsinit`, and we ignore the bundles directory from git.