### PR TITLE
cgroups: add support of devices deny for another use of cgroup devices

### DIFF
--- a/cgroups/fs/devices.go
+++ b/cgroups/fs/devices.go
@@ -32,6 +32,17 @@ func (s *DevicesGroup) Set(path string, cgroup *configs.Cgroup) error {
 				return err
 			}
 		}
+		return nil
+	}
+
+	if err := writeFile(path, "devices.allow", "a"); err != nil {
+		return err
+	}
+
+	for _, dev := range cgroup.DeniedDevices {
+		if err := writeFile(path, "devices.deny", dev.CgroupString()); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cgroups/fs/devices_test.go
+++ b/cgroups/fs/devices_test.go
@@ -17,7 +17,18 @@ var (
 			FileMode:    0666,
 		},
 	}
-	allowedList = "c 1:5 rwm"
+	allowedList   = "c 1:5 rwm"
+	deniedDevices = []*configs.Device{
+		{
+			Path:        "/dev/null",
+			Type:        'c',
+			Major:       1,
+			Minor:       3,
+			Permissions: "rwm",
+			FileMode:    0666,
+		},
+	}
+	deniedList = "c 1:3 rwm"
 )
 
 func TestDevicesSetAllow(t *testing.T) {
@@ -42,5 +53,30 @@ func TestDevicesSetAllow(t *testing.T) {
 
 	if value != allowedList {
 		t.Fatal("Got the wrong value, set devices.allow failed.")
+	}
+}
+
+func TestDevicesSetDeny(t *testing.T) {
+	helper := NewCgroupTestUtil("devices", t)
+	defer helper.cleanup()
+
+	helper.writeFileContents(map[string]string{
+		"devices.allow": "a",
+	})
+
+	helper.CgroupData.c.AllowAllDevices = true
+	helper.CgroupData.c.DeniedDevices = deniedDevices
+	devices := &DevicesGroup{}
+	if err := devices.Set(helper.CgroupPath, helper.CgroupData.c); err != nil {
+		t.Fatal(err)
+	}
+
+	value, err := getCgroupParamString(helper.CgroupPath, "devices.deny")
+	if err != nil {
+		t.Fatalf("Failed to parse devices.deny - %s", err)
+	}
+
+	if value != deniedList {
+		t.Fatal("Got the wrong value, set devices.deny failed.")
 	}
 }

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -421,6 +421,28 @@ func joinDevices(c *configs.Cgroup, pid int) error {
 		return err
 	}
 
+	if !c.AllowAllDevices {
+		if err := writeFile(path, "devices.deny", "a"); err != nil {
+			return err
+		}
+		for _, dev := range c.AllowedDevices {
+			if err := writeFile(path, "devices.allow", dev.CgroupString()); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	if err := writeFile(path, "devices.allow", "a"); err != nil {
+		return err
+	}
+
+	for _, dev := range c.DeniedDevices {
+		if err := writeFile(path, "devices.deny", dev.CgroupString()); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/configs/cgroup.go
+++ b/configs/cgroup.go
@@ -19,6 +19,8 @@ type Cgroup struct {
 
 	AllowedDevices []*Device `json:"allowed_devices"`
 
+	DeniedDevices []*Device `json:"denied_devices"`
+
 	// Memory limit (in bytes)
 	Memory int64 `json:"memory"`
 


### PR DESCRIPTION
Signed-off-by: Ma Shimiao <mashimiao.fnst@cn.fujitsu.com>

the original code usee cgroup devices, like:
group        whitelist entries                        denied devices
A                "c x:x rwm", "b x:* rwm"                 all the rest
I add another use method, you can pass parameters, like:
group        whitelist entries                        denied devices
A                all                                            "c x:x rwm", "b x:* rwm"