### PR TITLE
Add support for Premount and Postmount commands.

### DIFF
--- a/configs/mount.go
+++ b/configs/mount.go
@@ -18,4 +18,17 @@ type Mount struct {
 
 	// Relabel source if set, "z" indicates shared, "Z" indicates unshared.
 	Relabel string `json:"relabel"`
+
+	// Optional Command to be run before Source is mounted.
+	PremountCmds []Command `json:"premount_cmds"`
+
+	// Optional Command to be run after Source is mounted.
+	PostmountCmds []Command `json:"postmount_cmds"`
+}
+
+type Command struct {
+	Path string   `json:"path"`
+	Args []string `json:"args"`
+	Env  []string `json:"env"`
+	Dir  string   `json:"dir"`
 }

--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -80,7 +80,7 @@ func mountCmd(cmd configs.Command) error {
 	command.Env = cmd.Env
 	command.Dir = cmd.Dir
 	if out, err := command.CombinedOutput(); err != nil {
-		return fmt.Errorf("%s failed: %s: %v", cmd, string(out), err)
+		return fmt.Errorf("%#v failed: %s: %v", cmd, string(out), err)
 	}
 
 	return nil

--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -24,8 +25,19 @@ func setupRootfs(config *configs.Config, console *linuxConsole) (err error) {
 		return newSystemError(err)
 	}
 	for _, m := range config.Mounts {
+		for _, precmd := range m.PremountCmds {
+			if err := mountCmd(precmd); err != nil {
+				return newSystemError(err)
+			}
+		}
 		if err := mountToRootfs(m, config.Rootfs, config.MountLabel); err != nil {
 			return newSystemError(err)
+		}
+
+		for _, postcmd := range m.PostmountCmds {
+			if err := mountCmd(postcmd); err != nil {
+				return newSystemError(err)
+			}
 		}
 	}
 	if err := createDevices(config); err != nil {
@@ -59,6 +71,18 @@ func setupRootfs(config *configs.Config, console *linuxConsole) (err error) {
 		}
 	}
 	syscall.Umask(0022)
+	return nil
+}
+
+func mountCmd(cmd configs.Command) error {
+
+	command := exec.Command(cmd.Path, cmd.Args[:]...)
+	command.Env = cmd.Env
+	command.Dir = cmd.Dir
+	if out, err := command.CombinedOutput(); err != nil {
+		return fmt.Errorf("%s failed: %s: %v", cmd, string(out), err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
We want to allow docker to mount tmpfs directories over existing directories
in the image.  We will use this patch to pass commands from docker to
libcontainer.  The first command we will use is the tar command to gather
all of the contents of the destination directory before mounting, then after
we mount the post mount command will untar the content.

Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)