### PR TITLE
Add ChargeProcess to Container API.

### DIFF
--- a/cgroups/cgroups.go
+++ b/cgroups/cgroups.go
@@ -34,6 +34,9 @@ type Manager interface {
 
 	// Set the cgroup as configured.
 	Set(container *configs.Config) error
+
+	// Enters the specified process into the cgroup set.
+	AddProcess(pid int) error
 }
 
 type NotFoundError struct {

--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -161,6 +161,20 @@ func (m *Manager) Set(container *configs.Config) error {
 	return nil
 }
 
+func (m *Manager) AddProcess(pid int) error {
+	for name, path := range m.Paths {
+		_, ok := subsystems[name]
+		if !ok || !cgroups.PathExists(path) {
+			continue
+		}
+		if err := writeFile(path, CgroupProcesses, strconv.Itoa(pid)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // Freeze toggles the container's freezer cgroup depending on the state
 // provided
 func (m *Manager) Freeze(state configs.FreezerState) error {

--- a/cgroups/systemd/apply_nosystemd.go
+++ b/cgroups/systemd/apply_nosystemd.go
@@ -42,6 +42,10 @@ func (m *Manager) Set(container *configs.Config) error {
 	return nil, fmt.Errorf("Systemd not supported")
 }
 
+func (m *Manager) AddProcess(pid int) error {
+	return nil, fmt.Errorf("Systemd not supported")
+}
+
 func (m *Manager) Freeze(state configs.FreezerState) error {
 	return fmt.Errorf("Systemd not supported")
 }

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -350,6 +350,20 @@ func (m *Manager) Set(container *configs.Config) error {
 	panic("not implemented")
 }
 
+func (m *Manager) AddProcess(pid int) error {
+	for name, path := range m.Paths {
+		_, ok := subsystems[name]
+		if !ok || !cgroups.PathExists(path) {
+			continue
+		}
+		if err := writeFile(path, fs.CgroupProcesses, strconv.Itoa(pid)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func getUnitName(c *configs.Cgroup) string {
 	return fmt.Sprintf("%s-%s.scope", c.Parent, c.Name)
 }

--- a/container.go
+++ b/container.go
@@ -108,6 +108,15 @@ type Container interface {
 	// Systemerror - System error.
 	Start(process *Process) (err error)
 
+	// Charge the resource usage of the specified process to this container.
+	// Does not join the namespaces of the container.
+	// Process will be killed when the container is destroyed.
+	//
+	// errors:
+	// ContainerDestroyed - Container no longer exists,
+	// Systemerror - System error.
+	ChargeProcess(pid int) error
+
 	// Destroys the container after killing all running processes.
 	//
 	// Any event registrations are removed before the container is destroyed.

--- a/container_linux.go
+++ b/container_linux.go
@@ -112,6 +112,10 @@ func (c *linuxContainer) Start(process *Process) error {
 	return nil
 }
 
+func (c *linuxContainer) ChargeProcess(pid int) error {
+	return c.cgroupManager.AddProcess(pid)
+}
+
 func (c *linuxContainer) newParentProcess(p *Process, doInit bool) (parentProcess, error) {
 	parentPipe, childPipe, err := newPipe()
 	if err != nil {

--- a/container_linux_test.go
+++ b/container_linux_test.go
@@ -33,6 +33,10 @@ func (m *mockCgroupManager) Set(container *configs.Config) error {
 	return nil
 }
 
+func (m *mockCgroupManager) AddProcess(pid int) error {
+	return nil
+}
+
 func (m *mockCgroupManager) Destroy() error {
 	return nil
 }


### PR DESCRIPTION
This will allow charging of an existing processes' resources to a particular container. It does NOT enter the namespaces (since it can't really). Useful for resource-only containers as well as charging system daemons to containers when they are doing work on behalf of the container.

/cc @crosbymichael @vishh @avagin @rjnagal 