### PR TITLE
Fix pdeathsig and ppid for supervisor running as pid1

### DIFF
--- a/container_linux.go
+++ b/container_linux.go
@@ -140,7 +140,9 @@ func (c *linuxContainer) commandTemplate(p *Process, childPipe *os.File) (*exec.
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.ExtraFiles = []*os.File{childPipe}
-	cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+	// NOTE: when running a container with no PID namespace and the parent process spawning the container is
+	// PID1 the pdeathsig is being delivered to the container's init process by the kernel for some reason
+	// even with the parent still running.
 	if c.config.ParentDeathSignal > 0 {
 		cmd.SysProcAttr.Pdeathsig = syscall.Signal(c.config.ParentDeathSignal)
 	}

--- a/init_linux.go
+++ b/init_linux.go
@@ -69,7 +69,8 @@ func newContainerInit(t initType, pipe *os.File) (initer, error) {
 		}, nil
 	case initStandard:
 		return &linuxStandardInit{
-			config: config,
+			parentPid: syscall.Getppid(),
+			config:    config,
 		}, nil
 	}
 	return nil, fmt.Errorf("unknown init type %q", t)


### PR DESCRIPTION
For some reason when the supervisor of a container is PID1 the parent
death signal was being delivered to the container's init process even if
it did not die.  Also the ppid() will return 1 for a container running
in the pid namespace of it's parent and the parent is pid1.

Fixes: https://github.com/docker/docker/issues/12015
Signed-off-by: Michael Crosby <crosbymichael@gmail.com>