### PR TITLE
Change memory usage by minus cache memory

### DIFF
--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -94,7 +94,8 @@ func (s *MemoryGroup) GetStats(path string, stats *cgroups.Stats) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse memory.usage_in_bytes - %v", err)
 	}
-	stats.MemoryStats.Usage = value - stats.MemoryStats.Stats["cache"]
+	stats.MemoryStats.Cache = stats.MemoryStats.Stats["cache"]
+	stats.MemoryStats.Usage = value - stats.MemoryStats.Cache
 	value, err = getCgroupParamUint(path, "memory.max_usage_in_bytes")
 	if err != nil {
 		return fmt.Errorf("failed to parse memory.max_usage_in_bytes - %v", err)

--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -94,7 +94,7 @@ func (s *MemoryGroup) GetStats(path string, stats *cgroups.Stats) error {
 	if err != nil {
 		return fmt.Errorf("failed to parse memory.usage_in_bytes - %v", err)
 	}
-	stats.MemoryStats.Usage = value
+	stats.MemoryStats.Usage = value - stats.MemoryStats.Stats["cache"]
 	value, err = getCgroupParamUint(path, "memory.max_usage_in_bytes")
 	if err != nil {
 		return fmt.Errorf("failed to parse memory.max_usage_in_bytes - %v", err)

--- a/cgroups/fs/memory_test.go
+++ b/cgroups/fs/memory_test.go
@@ -128,7 +128,7 @@ func TestMemoryStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedStats := cgroups.MemoryStats{Usage: 1536, MaxUsage: 4096, Failcnt: 100, Stats: map[string]uint64{"cache": 512, "rss": 1024}}
+	expectedStats := cgroups.MemoryStats{Usage: 1536, Cache: 512, MaxUsage: 4096, Failcnt: 100, Stats: map[string]uint64{"cache": 512, "rss": 1024}}
 	expectMemoryStatEquals(t, expectedStats, actualStats.MemoryStats)
 }
 

--- a/cgroups/fs/memory_test.go
+++ b/cgroups/fs/memory_test.go
@@ -128,7 +128,7 @@ func TestMemoryStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	expectedStats := cgroups.MemoryStats{Usage: 2048, MaxUsage: 4096, Failcnt: 100, Stats: map[string]uint64{"cache": 512, "rss": 1024}}
+	expectedStats := cgroups.MemoryStats{Usage: 1536, MaxUsage: 4096, Failcnt: 100, Stats: map[string]uint64{"cache": 512, "rss": 1024}}
 	expectMemoryStatEquals(t, expectedStats, actualStats.MemoryStats)
 }
 

--- a/cgroups/stats.go
+++ b/cgroups/stats.go
@@ -31,8 +31,10 @@ type CpuStats struct {
 }
 
 type MemoryStats struct {
-	// current res_counter usage for memory
+	// current res_counter usage for memory(without cache part)
 	Usage uint64 `json:"usage,omitempty"`
+	// memory used for cache
+	Cache uint64 `json:"cache,omitempty"`
 	// maximum usage ever recorded.
 	MaxUsage uint64 `json:"max_usage,omitempty"`
 	// TODO(vishh): Export these as stronger types.


### PR DESCRIPTION
Fixes [#10824](https://github.com/docker/docker/issues/10824)

Calculate the real usage_memory by "used - buffers cached".

Using cgroup file is  "memory.usage_in_bytes - memory.stat.cache"

Signed-off-by: Sun Jianbo <wonderflow@zju.edu.cn>