### PR TITLE
Add value checking on relabel command for selinux

### DIFF
--- a/label/label_selinux.go
+++ b/label/label_selinux.go
@@ -104,7 +104,13 @@ func Relabel(path string, fileLabel string, relabel string) error {
 	if fileLabel == "" {
 		return nil
 	}
-	if relabel == "z" {
+	if !strings.ContainsAny(relabel, "zZ") {
+		return nil
+	}
+	if strings.Contains(relabel, "z") && strings.Contains(relabel, "Z") {
+		return fmt.Errorf("Bad SELinux option z and Z can not be used together")
+	}
+	if strings.Contains(relabel, "z") {
 		c := selinux.NewContext(fileLabel)
 		c["level"] = "s0"
 		fileLabel = c.Get()

--- a/label/label_selinux_test.go
+++ b/label/label_selinux_test.go
@@ -87,3 +87,22 @@ func TestDuplicateLabel(t *testing.T) {
 		t.Errorf("DisableSecOpt Failed level incorrect")
 	}
 }
+func TestRelabel(t *testing.T) {
+	testdir := "/tmp/test"
+	label := "system_u:system_r:svirt_sandbox_file_t:s0:c1,c2"
+	if err := Relabel(testdir, "", "z"); err != nil {
+		t.Fatal("Relabel with no label failed: %v", err)
+	}
+	if err := Relabel(testdir, label, ""); err != nil {
+		t.Fatal("Relabel with no relabel field failed: %v", err)
+	}
+	if err := Relabel(testdir, label, "z"); err != nil {
+		t.Fatal("Relabel shared failed: %v", err)
+	}
+	if err := Relabel(testdir, label, "Z"); err != nil {
+		t.Fatal("Relabel unshared failed: %v", err)
+	}
+	if err := Relabel(testdir, label, "zZ"); err == nil {
+		t.Fatal("Relabel with shared and unshared succeeded: %v", err)
+	}
+}


### PR DESCRIPTION
Currently relabel requires an exact match on passed in relabel string.  This patch will allow the passing of multiple params in the string, and just look for Z or z

Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)