### PR TITLE
Fix share ns from container and the container has shared ns with host

### DIFF
--- a/container_linux.go
+++ b/container_linux.go
@@ -303,7 +303,12 @@ func (c *linuxContainer) currentState() (*State, error) {
 		CgroupPaths:          c.cgroupManager.GetPaths(),
 		NamespacePaths:       make(map[configs.NamespaceType]string),
 	}
-	for _, ns := range c.config.Namespaces {
+	for _, ns := range []configs.Namespace{
+		{Type: "NEWNS"},
+		{Type: "NEWUTS"},
+		{Type: "NEWIPC"},
+		{Type: "NEWPID"},
+		{Type: "NEWNET"}} {
 		state.NamespacePaths[ns.Type] = ns.GetPath(c.initProcess.pid())
 	}
 	return state, nil


### PR DESCRIPTION
Signed-off-by: Lei Jitang <leijitang@huawei.com>

when create a container with `--net=container:parent`, and the net mode of container `parent` 
is `--net=host`, something wrong. Steps to reproduce:
step 1 `docker run --rm -ti --name parent --net=host busybox`
<pre><code>[l00284783@localhost docker]$ docker run --rm -ti --name parent --net=host busybox
/ # ifconfig
docker0   Link encap:Ethernet  HWaddr 00:00:00:00:00:00
          inet addr:172.17.42.1  Bcast:0.0.0.0  Mask:255.255.0.0
          UP BROADCAST MULTICAST  MTU:1500  Metric:1
          RX packets:1761 errors:0 dropped:0 overruns:0 frame:0
          TX packets:1609 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:156885 (153.2 KiB)  TX bytes:2676950 (2.5 MiB)

ens3f0    Link encap:Ethernet  HWaddr 52:54:00:0E:AF:A0
          inet addr:9.81.1.183  Bcast:9.81.255.255  Mask:255.255.0.0
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:134326 errors:0 dropped:0 overruns:0 frame:0
          TX packets:71062 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:79910134 (76.2 MiB)  TX bytes:11759548 (11.2 MiB)

lo        Link encap:Local Loopback
          inet addr:127.0.0.1  Mask:255.0.0.0
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:7112 errors:0 dropped:0 overruns:0 frame:0
          TX packets:7112 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:2819299 (2.6 MiB)  TX bytes:2819299 (2.6 MiB)

/ #</code></pre>
Step2 `docker run --name child --net=container:parent busybox ifconfig`
<pre><code>[l00284783@localhost docker]$ docker run --name child --net=container:parent busybox ifconfig
lo        Link encap:Local Loopback
          inet addr:127.0.0.1  Mask:255.0.0.0
          UP LOOPBACK RUNNING  MTU:65536  Metric:1
          RX packets:0 errors:0 dropped:0 overruns:0 frame:0
          TX packets:0 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:0
          RX bytes:0 (0.0 B)  TX bytes:0 (0.0 B)
</code></pre>

The container `child` suppose to have the same net namespace of the container `parent` and apparently its not.

The reason is that when a container is `--net=host`,  `state.NamespacePaths[NEWNET]` is nil
due to the https://github.com/docker/docker/blob/master/daemon/execdriver/native/create.go#L93
has remove `configs.NEWNET` and https://github.com/docker/libcontainer/blob/master/container_linux.go#L306 will not store the net namespace path, so any container want to share net namespace with this container can't work.

I think ipc namespace has same problem, but I not sure, I haven't test it.

I think the ns path should always store in `state.NamespacePaths` no matter it is a private or shared.

I think this patch can solve this.