### PR TITLE
Append childpipe for adding addtional Fds to container

### DIFF
--- a/container_linux.go
+++ b/container_linux.go
@@ -139,7 +139,7 @@ func (c *linuxContainer) commandTemplate(p *Process, childPipe *os.File) (*exec.
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
-	cmd.ExtraFiles = []*os.File{childPipe}
+	cmd.ExtraFiles = append([]*os.File{childPipe}, p.ExtraFiles...)
 	// NOTE: when running a container with no PID namespace and the parent process spawning the container is
 	// PID1 the pdeathsig is being delivered to the container's init process by the kernel for some reason
 	// even with the parent still running.
@@ -195,13 +195,14 @@ func (c *linuxContainer) newSetnsProcess(p *Process, cmd *exec.Cmd, parentPipe, 
 
 func (c *linuxContainer) newInitConfig(process *Process) *initConfig {
 	return &initConfig{
-		Config:       c.config,
-		Args:         process.Args,
-		Env:          process.Env,
-		User:         process.User,
-		Cwd:          process.Cwd,
-		Console:      process.consolePath,
-		Capabilities: process.Capabilities,
+		Config:           c.config,
+		Args:             process.Args,
+		Env:              process.Env,
+		User:             process.User,
+		Cwd:              process.Cwd,
+		Console:          process.consolePath,
+		Capabilities:     process.Capabilities,
+		PassedFilesCount: len(process.ExtraFiles),
 	}
 }
 

--- a/factory.go
+++ b/factory.go
@@ -33,14 +33,12 @@ type Factory interface {
 	Load(id string) (Container, error)
 
 	// StartInitialization is an internal API to libcontainer used during the rexec of the
-	// container.  pipefd is the fd to the child end of the pipe used to syncronize the
-	// parent and child process providing state and configuration to the child process and
-	// returning any errors during the init of the container
+	// container.
 	//
 	// Errors:
-	// pipe connection error
-	// system error
-	StartInitialization(pipefd uintptr) error
+	// Pipe connection error
+	// System error
+	StartInitialization() error
 
 	// Type returns info string about factory type (e.g. lxc, libcontainer...)
 	Type() string

--- a/factory_linux.go
+++ b/factory_linux.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"syscall"
 
 	"github.com/docker/docker/pkg/mount"
@@ -194,7 +195,11 @@ func (l *LinuxFactory) Type() string {
 
 // StartInitialization loads a container by opening the pipe fd from the parent to read the configuration and state
 // This is a low level implementation detail of the reexec and should not be consumed externally
-func (l *LinuxFactory) StartInitialization(pipefd uintptr) (err error) {
+func (l *LinuxFactory) StartInitialization() (err error) {
+	pipefd, err := strconv.Atoi(os.Getenv("_LIBCONTAINER_INITPIPE"))
+	if err != nil {
+		return err
+	}
 	var (
 		pipe = os.NewFile(uintptr(pipefd), "pipe")
 		it   = initType(os.Getenv("_LIBCONTAINER_INITTYPE"))

--- a/init_linux.go
+++ b/init_linux.go
@@ -40,14 +40,15 @@ type network struct {
 
 // initConfig is used for transferring parameters from Exec() to Init()
 type initConfig struct {
-	Args         []string        `json:"args"`
-	Env          []string        `json:"env"`
-	Cwd          string          `json:"cwd"`
-	Capabilities []string        `json:"capabilities"`
-	User         string          `json:"user"`
-	Config       *configs.Config `json:"config"`
-	Console      string          `json:"console"`
-	Networks     []*network      `json:"network"`
+	Args             []string        `json:"args"`
+	Env              []string        `json:"env"`
+	Cwd              string          `json:"cwd"`
+	Capabilities     []string        `json:"capabilities"`
+	User             string          `json:"user"`
+	Config           *configs.Config `json:"config"`
+	Console          string          `json:"console"`
+	Networks         []*network      `json:"network"`
+	PassedFilesCount int             `json:"passed_files_count"`
 }
 
 type initer interface {
@@ -95,10 +96,22 @@ func populateProcessEnvironment(env []string) error {
 // and working dir, and closes any leaked file descriptors
 // before executing the command inside the namespace
 func finalizeNamespace(config *initConfig) error {
-	// Ensure that all non-standard fds we may have accidentally
+	// FD 3 is the child pipe, which needs to be closed.
+	// Additional file descriptors starts from 3 to (3 + n)
+	// To fix the order all additional file descriptors
+	// are shiftet by one right
+	for fd := 3; fd < (config.PassedFilesCount + 3); fd++ {
+		err := syscall.Dup2(fd+1, fd)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Ensure that all unwanted fds we may have accidentally
 	// inherited are marked close-on-exec so they stay out of the
 	// container
-	if err := utils.CloseExecFrom(3); err != nil {
+
+	if err := utils.CloseExecFrom(config.PassedFilesCount + 3); err != nil {
 		return err
 	}
 

--- a/init_linux.go
+++ b/init_linux.go
@@ -96,21 +96,9 @@ func populateProcessEnvironment(env []string) error {
 // and working dir, and closes any leaked file descriptors
 // before executing the command inside the namespace
 func finalizeNamespace(config *initConfig) error {
-	// FD 3 is the child pipe, which needs to be closed.
-	// Additional file descriptors starts from 3 to (3 + n)
-	// To fix the order all additional file descriptors
-	// are shiftet by one right
-	for fd := 3; fd < (config.PassedFilesCount + 3); fd++ {
-		err := syscall.Dup2(fd+1, fd)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Ensure that all unwanted fds we may have accidentally
 	// inherited are marked close-on-exec so they stay out of the
 	// container
-
 	if err := utils.CloseExecFrom(config.PassedFilesCount + 3); err != nil {
 		return err
 	}

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -21,7 +21,7 @@ func init() {
 	if err != nil {
 		log.Fatalf("unable to initialize for container: %s", err)
 	}
-	if err := factory.StartInitialization(3); err != nil {
+	if err := factory.StartInitialization(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/nsinit/init.go
+++ b/nsinit/init.go
@@ -20,7 +20,7 @@ var initCommand = cli.Command{
 		if err != nil {
 			fatal(err)
 		}
-		if err := factory.StartInitialization(3); err != nil {
+		if err := factory.StartInitialization(); err != nil {
 			fatal(err)
 		}
 		panic("This line should never been executed")

--- a/process.go
+++ b/process.go
@@ -38,6 +38,9 @@ type Process struct {
 	// Stderr is a pointer to a writer which receives the standard error stream.
 	Stderr io.Writer
 
+	// ExtraFiles specifies additional open files to be inherited by the container
+	ExtraFiles []*os.File
+
 	// consolePath is the path to the console allocated to the container.
 	consolePath string
 


### PR DESCRIPTION
This takes the work done in #496 and changes this so that we append the childPipe to the end of the processes FD set.  We provide an internal env var for identifying the childPipe's fd to the init process and any of the user defined extra files will be exactly how they specify them.  

Closes #496