### PR TITLE
Add arch support for ARMv8 and PowerPC, and fix ARMv7

### DIFF
--- a/system/setns_linux.go
+++ b/system/setns_linux.go
@@ -15,6 +15,7 @@ var setNsMap = map[string]uintptr{
 	"linux/arm64":   268,
 	"linux/amd64":   308,
 	"linux/arm":     375,
+	"linux/ppc":     350,
 	"linux/ppc64":   350,
 	"linux/ppc64le": 350,
 	"linux/s390x":   339,

--- a/system/setns_linux.go
+++ b/system/setns_linux.go
@@ -12,6 +12,7 @@ import (
 // We are declaring the macro here because the SETNS syscall does not exist in th stdlib
 var setNsMap = map[string]uintptr{
 	"linux/386":     346,
+	"linux/arm64":   268,
 	"linux/amd64":   308,
 	"linux/arm":     374,
 	"linux/ppc64":   350,

--- a/system/setns_linux.go
+++ b/system/setns_linux.go
@@ -14,7 +14,7 @@ var setNsMap = map[string]uintptr{
 	"linux/386":     346,
 	"linux/arm64":   268,
 	"linux/amd64":   308,
-	"linux/arm":     374,
+	"linux/arm":     375,
 	"linux/ppc64":   350,
 	"linux/ppc64le": 350,
 	"linux/s390x":   339,

--- a/system/syscall_linux_64.go
+++ b/system/syscall_linux_64.go
@@ -1,4 +1,4 @@
-// +build linux,arm64 linux,amd64 linux,ppc64 linux,ppc64le linux,s390x
+// +build linux,arm64 linux,amd64 linux,ppc linux,ppc64 linux,ppc64le linux,s390x
 
 package system
 

--- a/system/syscall_linux_64.go
+++ b/system/syscall_linux_64.go
@@ -1,4 +1,4 @@
-// +build linux,amd64 linux,ppc64 linux,ppc64le linux,s390x
+// +build linux,arm64 linux,amd64 linux,ppc64 linux,ppc64le linux,s390x
 
 package system
 


### PR DESCRIPTION
The ARMv8 commit should be self-explanatory.

The ARMv7 commit is fixing something that's been wrong since day 1, though the lack of complaints due to it probably shows how often this code-path isn't followed on ARM.  Still, I saw it in passing and fixed it anyway.

The PowerPC commit is similarly self-explanatory to the ARMv8 one, though also shows that syscall_linux_64.go is fairly poorly named.  Really, syscall_linux* should probably go away and be replaced by an import C that calls the glibc setuid() and setgid() wrappers, since they magically always hit the right syscall, and we don't have to have knowledge of what arch supports what, but I went for the most minimally invasive fix here just to make it build happily.

Tested as backports to docker 1.5.0 on amd64, i386, armhf, arm64, powerpc, and ppc64el.