### PR TITLE
WIP: Mounting cgroups readonly into containers

### DIFF
--- a/init_linux.go
+++ b/init_linux.go
@@ -40,15 +40,16 @@ type network struct {
 
 // initConfig is used for transferring parameters from Exec() to Init()
 type initConfig struct {
-	Args             []string        `json:"args"`
-	Env              []string        `json:"env"`
-	Cwd              string          `json:"cwd"`
-	Capabilities     []string        `json:"capabilities"`
-	User             string          `json:"user"`
-	Config           *configs.Config `json:"config"`
-	Console          string          `json:"console"`
-	Networks         []*network      `json:"network"`
-	PassedFilesCount int             `json:"passed_files_count"`
+	Args             []string         `json:"args"`
+	Env              []string         `json:"env"`
+	Cwd              string           `json:"cwd"`
+	Capabilities     []string         `json:"capabilities"`
+	User             string           `json:"user"`
+	Config           *configs.Config  `json:"config"`
+	Console          string           `json:"console"`
+	Networks         []*network       `json:"network"`
+	PassedFilesCount int              `json:"passed_files_count"`
+	CgroupMounts     []*configs.Mount `json:"cgroup_mounts"`
 }
 
 type initer interface {

--- a/nsinit/exec.go
+++ b/nsinit/exec.go
@@ -23,6 +23,7 @@ var execCommand = cli.Command{
 	Action: execAction,
 	Flags: append([]cli.Flag{
 		cli.BoolFlag{Name: "tty,t", Usage: "allocate a TTY to the container"},
+		cli.BoolFlag{Name: "systemd", Usage: "Use systemd for managing cgroups, if available"},
 		cli.StringFlag{Name: "id", Value: "nsinit", Usage: "specify the ID for a container"},
 		cli.StringFlag{Name: "config", Value: "", Usage: "path to the configuration file"},
 		cli.StringFlag{Name: "user,u", Value: "root", Usage: "set the user, uid, and/or gid for the process"},

--- a/nsinit/utils.go
+++ b/nsinit/utils.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/docker/libcontainer"
+	"github.com/docker/libcontainer/cgroups/systemd"
 	"github.com/docker/libcontainer/configs"
 )
 
@@ -29,7 +30,11 @@ func loadConfig(context *cli.Context) (*configs.Config, error) {
 }
 
 func loadFactory(context *cli.Context) (libcontainer.Factory, error) {
-	return libcontainer.New(context.GlobalString("root"), libcontainer.Cgroupfs)
+	cgm := libcontainer.Cgroupfs
+	if context.Bool("systemd") && systemd.UseSystemd() {
+		cgm = libcontainer.SystemdCgroups
+	}
+	return libcontainer.New(context.GlobalString("root"), cgm)
 }
 
 func getContainer(context *cli.Context) (libcontainer.Container, error) {

--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -19,13 +19,21 @@ const defaultMountFlags = syscall.MS_NOEXEC | syscall.MS_NOSUID | syscall.MS_NOD
 
 // setupRootfs sets up the devices, mount points, and filesystems for use inside a
 // new mount namespace.
-func setupRootfs(config *configs.Config, console *linuxConsole) (err error) {
+func setupRootfs(config *configs.Config, cgroupMounts []*configs.Mount, console *linuxConsole) (err error) {
 	if err := prepareRoot(config); err != nil {
 		return newSystemError(err)
 	}
 	for _, m := range config.Mounts {
 		if err := mountToRootfs(m, config.Rootfs, config.MountLabel); err != nil {
 			return newSystemError(err)
+		}
+	}
+
+	if cgroupMounts != nil {
+		for _, m := range cgroupMounts {
+			if err := mountToRootfs(m, config.Rootfs, config.MountLabel); err != nil {
+				return newSystemError(err)
+			}
 		}
 	}
 	if err := createDevices(config); err != nil {

--- a/standard_init_linux.go
+++ b/standard_init_linux.go
@@ -49,7 +49,7 @@ func (l *linuxStandardInit) Init() error {
 	label.Init()
 	// InitializeMountNamespace() can be executed only for a new mount namespace
 	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
-		if err := setupRootfs(l.config.Config, console); err != nil {
+		if err := setupRootfs(l.config.Config, l.config.CgroupMounts, console); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
This is a PoC / RFC to explore if this is worth doing. (I have only tested this with systemd and will add fs support/refactor if we think this is useful).

We only mount the container's own cgroups under /cgroups.
