### PR TITLE
integration: wait all test processes

### DIFF
--- a/integration/execin_test.go
+++ b/integration/execin_test.go
@@ -311,6 +311,8 @@ func TestExecinPassExtraFiles(t *testing.T) {
 	}
 
 	waitProcess(inprocess, t)
+	stdinW.Close()
+	waitProcess(process, t)
 
 	out := string(stdout.Bytes())
 	// fd 5 is the directory handle for /proc/$$/fd


### PR DESCRIPTION
Otherwise a container cannot be destroyed and we will get an error
in the next case:
go test -v .
=== RUN TestExecPS
--- FAIL: TestExecPS (0.02s)
        exec_test.go:43: <nil>: [0] Id already in use: Container with id exists: testCT

Cc: @LK4D4 
Signed-off-by: Andrey Vagin <avagin@openvz.org>