### PR TITLE
check "/sbin/apparmor_parser" in apparmor.IsEnabled()

### DIFF
--- a/apparmor/apparmor.go
+++ b/apparmor/apparmor.go
@@ -14,8 +14,10 @@ import (
 
 func IsEnabled() bool {
 	if _, err := os.Stat("/sys/kernel/security/apparmor"); err == nil && os.Getenv("container") == "" {
-		buf, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
-		return err == nil && len(buf) > 1 && buf[0] == 'Y'
+		if _, err = os.Stat("/sbin/apparmor_parser"); err == nil {
+			buf, err := ioutil.ReadFile("/sys/module/apparmor/parameters/enabled")
+			return err == nil && len(buf) > 1 && buf[0] == 'Y'
+		}
 	}
 	return false
 }


### PR DESCRIPTION
In ubuntu 14.04, Apparmor is installed by default. When uninstalling apparmor with `apt-get purge apparmor`, `/sbin/apparmor_parser` will be delete. However, `/sys/kernel/security/apparmor` and `/sys/module/apparmor/parameters/enabled` remains on the host, resulting in the following error
```
FATA[0000] Error loading docker apparmor profile: fork/exec /sbin/apparmor_parser: no such file or directory () 
```