### PR TITLE
We want to prevent users from accidently attempting to relabel /, /etc and /usr

### DIFF
--- a/label/label_selinux.go
+++ b/label/label_selinux.go
@@ -101,8 +101,14 @@ func SetFileCreateLabel(fileLabel string) error {
 // the MCS label should continue to be used.  SELinux will use this field
 // to make sure the content can not be shared by other containes.
 func Relabel(path string, fileLabel string, relabel string) error {
+	exclude_path := []string{"/", "/usr", "/etc"}
 	if fileLabel == "" {
 		return nil
+	}
+	for _, p := range exclude_path {
+		if path == p {
+			return fmt.Errorf("Relabeling of %s is not allowed", path)
+		}
 	}
 	if !strings.ContainsAny(relabel, "zZ") {
 		return nil

--- a/label/label_selinux_test.go
+++ b/label/label_selinux_test.go
@@ -103,6 +103,15 @@ func TestRelabel(t *testing.T) {
 		t.Fatal("Relabel unshared failed: %v", err)
 	}
 	if err := Relabel(testdir, label, "zZ"); err == nil {
-		t.Fatal("Relabel with shared and unshared succeeded: %v", err)
+		t.Fatal("Relabel with shared and unshared succeeded")
+	}
+	if err := Relabel("/etc", label, "zZ"); err == nil {
+		t.Fatal("Relabel /etc succeeded")
+	}
+	if err := Relabel("/", label, ""); err == nil {
+		t.Fatal("Relabel / succeeded")
+	}
+	if err := Relabel("/usr", label, "Z"); err == nil {
+		t.Fatal("Relabel /usr succeeded")
 	}
 }


### PR DESCRIPTION
While we know this is by no means complete it at least stops users from
doing a common ignorant action. rm -rf /  has a similar protection.

Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)

