### PR TITLE
Adds support for setting system properties.

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -99,6 +99,10 @@ type Config struct {
 	// ReadonlyPaths specifies paths within the container's rootfs to remount as read-only
 	// so that these files prevent any writes.
 	ReadonlyPaths []string `json:"readonly_paths"`
+
+	// SystemProperties is a map of properties and their values. It is the equivalent of using
+	// sysctl -w my.property.name value in Linux.
+	SystemProperties map[string]string `json:"system_properties"`
 }
 
 // Gets the root uid for the process on host which could be non-zero

--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -386,4 +387,11 @@ func maskFile(path string) error {
 		return err
 	}
 	return nil
+}
+
+// writeSystemProperty writes the value to a path under /proc/sys as determined from the key.
+// For e.g. net.ipv4.ip_forward translated to /proc/sys/net/ipv4/ip_forward.
+func writeSystemProperty(key, value string) error {
+	keyPath := strings.Replace(key, ".", "/", -1)
+	return ioutil.WriteFile(path.Join("/proc/sys", keyPath), []byte(value), 0644)
 }

--- a/standard_init_linux.go
+++ b/standard_init_linux.go
@@ -64,6 +64,13 @@ func (l *linuxStandardInit) Init() error {
 	if err := label.SetProcessLabel(l.config.Config.ProcessLabel); err != nil {
 		return err
 	}
+
+	for key, value := range l.config.Config.SystemProperties {
+		if err := writeSystemProperty(key, value); err != nil {
+			return err
+		}
+	}
+
 	for _, path := range l.config.Config.ReadonlyPaths {
 		if err := remountReadonly(path); err != nil {
 			return err


### PR DESCRIPTION
This allows one to do the equivalent of sysctl -w ip.ipv4.ip_forward 1 or any such property.

I will add tests and other bits if we are okay adding this.
Signed-off-by: Mrunal Patel <mrunalp@gmail.com>