### PR TITLE
cr: don't remove images after restore

### DIFF
--- a/container_linux.go
+++ b/container_linux.go
@@ -563,10 +563,6 @@ func (c *linuxContainer) criuNotifications(resp *criurpc.CriuResp, process *Proc
 		break
 
 	case notify.GetScript() == "post-restore":
-		// In many case, restore from the images can be done only once.
-		// If we want to create snapshots, we need to snapshot the file system.
-		os.RemoveAll(imagePath)
-
 		pid := notify.GetPid()
 		r, err := newRestoredProcess(int(pid))
 		if err != nil {


### PR DESCRIPTION
This code was added when images were saved in a factory root directory and in
addition this directory was used as a flag.

Now an user can decide when images can be removed.

Cc: @boucher
Signed-off-by: Andrey Vagin <avagin@openvz.org>