### PR TITLE
fix freeze systemd test

### DIFF
--- a/integration/exec_test.go
+++ b/integration/exec_test.go
@@ -425,11 +425,12 @@ func testFreeze(t *testing.T, systemd bool) {
 	defer remove(rootfs)
 
 	config := newTemplateConfig(rootfs)
+	cgm := libcontainer.Cgroupfs
 	if systemd {
-		config.Cgroups.Slice = "system.slice"
+		cgm = libcontainer.SystemdCgroups
 	}
 
-	factory, err := libcontainer.New(root, libcontainer.Cgroupfs)
+	factory, err := libcontainer.New(root, cgm)
 	ok(t, err)
 
 	container, err := factory.Create("test", config)


### PR DESCRIPTION
Made a mistake before, freeze test doesn't use newContainer,
systemd test doesn't actually work.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>