### PR TITLE
Mount /sys/fs/cgroup into the container

### DIFF
--- a/init_linux.go
+++ b/init_linux.go
@@ -40,15 +40,16 @@ type network struct {
 
 // initConfig is used for transferring parameters from Exec() to Init()
 type initConfig struct {
-	Args             []string        `json:"args"`
-	Env              []string        `json:"env"`
-	Cwd              string          `json:"cwd"`
-	Capabilities     []string        `json:"capabilities"`
-	User             string          `json:"user"`
-	Config           *configs.Config `json:"config"`
-	Console          string          `json:"console"`
-	Networks         []*network      `json:"network"`
-	PassedFilesCount int             `json:"passed_files_count"`
+	Args             []string         `json:"args"`
+	Env              []string         `json:"env"`
+	Cwd              string           `json:"cwd"`
+	Capabilities     []string         `json:"capabilities"`
+	User             string           `json:"user"`
+	Config           *configs.Config  `json:"config"`
+	Console          string           `json:"console"`
+	Networks         []*network       `json:"network"`
+	PassedFilesCount int              `json:"passed_files_count"`
+	CgroupMounts     []*configs.Mount `json:"cgroup_mounts"`
 }
 
 type initer interface {

--- a/process_linux.go
+++ b/process_linux.go
@@ -5,12 +5,15 @@ package libcontainer
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"syscall"
 
 	"github.com/docker/libcontainer/cgroups"
+	"github.com/docker/libcontainer/cgroups/systemd"
+	"github.com/docker/libcontainer/configs"
 	"github.com/docker/libcontainer/system"
 )
 
@@ -151,6 +154,52 @@ func (p *initProcess) pid() int {
 	return p.cmd.Process.Pid
 }
 
+func addCgroupMounts(p *initProcess, cgroupPaths map[string]string) {
+	var cgroupMounts []*configs.Mount
+
+	cgroupFSPath, err := cgroups.FindCgroupMountpointDir()
+	if err != nil {
+		cgroupFSPath = "/sys/fs/cgroup"
+	}
+
+	if systemd.UseSystemd() {
+		cgroupMounts = append(cgroupMounts, &configs.Mount{
+			Source:      cgroupFSPath,
+			Destination: cgroupFSPath,
+			Device:      "bind",
+			Flags:       syscall.MS_BIND | syscall.MS_REC | syscall.MS_RDONLY,
+		})
+	} else {
+		cgroupMounts = append(cgroupMounts, &configs.Mount{
+			Source:      "tmpfs",
+			Destination: cgroupFSPath,
+			Device:      "tmpfs",
+			Flags:       syscall.MS_REC,
+		})
+	}
+
+	cgroupMounts = append(cgroupMounts, &configs.Mount{
+		Source:      "tmpfs",
+		Destination: cgroupFSPath + "/systemd",
+		Device:      "tmpfs",
+		Flags:       syscall.MS_REC | syscall.MS_RDONLY,
+	})
+
+	for cg, path := range cgroupPaths {
+		if _, err := os.Stat(path); err != nil {
+			continue
+		}
+		dest := fmt.Sprintf("%s/%s", cgroupFSPath, cg)
+		cgroupMounts = append(cgroupMounts, &configs.Mount{
+			Source:      path,
+			Destination: dest,
+			Device:      "bind",
+			Flags:       syscall.MS_BIND | syscall.MS_REC | syscall.MS_RDONLY,
+		})
+	}
+	p.config.CgroupMounts = cgroupMounts
+}
+
 func (p *initProcess) start() error {
 	defer p.parentPipe.Close()
 	err := p.cmd.Start()
@@ -163,6 +212,9 @@ func (p *initProcess) start() error {
 	if err := p.manager.Apply(p.pid()); err != nil {
 		return newSystemError(err)
 	}
+
+	addCgroupMounts(p, p.manager.GetPaths())
+
 	defer func() {
 		if err != nil {
 			// TODO: should not be the responsibility to call here

--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -19,13 +19,21 @@ const defaultMountFlags = syscall.MS_NOEXEC | syscall.MS_NOSUID | syscall.MS_NOD
 
 // setupRootfs sets up the devices, mount points, and filesystems for use inside a
 // new mount namespace.
-func setupRootfs(config *configs.Config, console *linuxConsole) (err error) {
+func setupRootfs(config *configs.Config, cgroupMounts []*configs.Mount, console *linuxConsole) (err error) {
 	if err := prepareRoot(config); err != nil {
 		return newSystemError(err)
 	}
 	for _, m := range config.Mounts {
 		if err := mountToRootfs(m, config.Rootfs, config.MountLabel); err != nil {
 			return newSystemError(err)
+		}
+	}
+
+	if cgroupMounts != nil {
+		for _, m := range cgroupMounts {
+			if err := mountToRootfs(m, config.Rootfs, config.MountLabel); err != nil {
+				return newSystemError(err)
+			}
 		}
 	}
 	if err := createDevices(config); err != nil {

--- a/standard_init_linux.go
+++ b/standard_init_linux.go
@@ -49,7 +49,7 @@ func (l *linuxStandardInit) Init() error {
 	label.Init()
 	// InitializeMountNamespace() can be executed only for a new mount namespace
 	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
-		if err := setupRootfs(l.config.Config, console); err != nil {
+		if err := setupRootfs(l.config.Config, l.config.CgroupMounts, console); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Then mount all of the config directories specific to the container.

This pull request grabs some of the ideas from https://github.com/docker/libcontainer/pull/528 and mounts them at the standard location under /sys/fs/cgroup.  

One of my goals is to get systemd to run within a container without having to to a -v /sys/fs/cgroup:/sys/fs/cgroup:ro.

Up til now I have not figured how to fool it without mounting the file system in.  The only problem I see with mounting it in is a leak of information about other processes on the system.

Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)