### PR TITLE
Exclude the root path from mount point paths.

### DIFF
--- a/container_linux.go
+++ b/container_linux.go
@@ -325,7 +325,13 @@ func (c *linuxContainer) Checkpoint(imagePath string) error {
 	}
 	for _, m := range c.config.Mounts {
 		if m.Device == "bind" {
+			mountDest := m.Destination
+			if strings.HasPrefix(mountDest, c.config.Rootfs) {
+				mountDest = mountDest[len(c.config.Rootfs):]
+			}
+
 			extMnt := new(criurpc.ExtMountMap)
+			extMnt.Key = proto.String(mountDest)
 			extMnt.Key = proto.String(m.Destination)
 			extMnt.Val = proto.String(m.Destination)
 			req.Opts.ExtMnt = append(req.Opts.ExtMnt, extMnt)


### PR DESCRIPTION
This change was necessary for me to get criu/libcontainer running inside of Docker.