### PR TITLE
WIP: Support chroot with no NEWNS

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -19,10 +19,6 @@ type IDMap struct {
 type Config struct {
 	// NoPivotRoot will use MS_MOVE and a chroot to jail the process into the container's rootfs
 	// This is a common option when the container is running in ramdisk
-	NoPivotRoot bool `json:"no_pivot_root"`
-
-	// ParentDeathSignal specifies the signal that is sent to the container's process in the case
-	// that the parent process dies.
 	ParentDeathSignal int `json:"parent_death_signal"`
 
 	// PivotDir allows a custom directory inside the container's root filesystem to be used as pivot, when NoPivotRoot is not set.
@@ -96,6 +92,11 @@ type Config struct {
 	// ReadonlyPaths specifies paths within the container's rootfs to remount as read-only
 	// so that these files prevent any writes.
 	ReadonlyPaths []string `json:"readonly_paths"`
+
+	// Chroot indicates that the container's process should be chrooted to the Rootfs
+	// If a mount namespace is created this means that we prefer to chroot rather than
+	// pivot_root.  If there is no mount namespace a regular Chroot will be done.
+	Chroot bool `json:"chroot"`
 }
 
 // Gets the root uid for the process on host which could be non-zero

--- a/configs/validate/config.go
+++ b/configs/validate/config.go
@@ -72,10 +72,11 @@ func (v *ConfigValidator) hostname(config *configs.Config) error {
 
 func (v *ConfigValidator) security(config *configs.Config) error {
 	// restrict sys without mount namespace
-	if (len(config.MaskPaths) > 0 || len(config.ReadonlyPaths) > 0) &&
-		!config.Namespaces.Contains(configs.NEWNS) {
-		return fmt.Errorf("unable to restrict sys entries without a private MNT namespace")
-	}
+        // TODO: do proper validation here
+	//if (len(config.MaskPaths) > 0 || len(config.ReadonlyPaths) > 0) &&
+	//	!config.Namespaces.Contains(configs.NEWNS) {
+	//	return fmt.Errorf("unable to restrict sys entries without a private MNT namespace")
+	//}
 	return nil
 }
 

--- a/container_linux.go
+++ b/container_linux.go
@@ -229,7 +229,12 @@ func (c *linuxContainer) Destroy() error {
 		}
 	}
 	err = c.cgroupManager.Destroy()
-	if rerr := os.RemoveAll(c.root); err == nil {
+	if !c.config.Namespaces.Contains(configs.NEWNS) {
+		if err := teardownRootfs(c.config); err != nil {
+			log.Warn(err)
+		}
+	}
+	if rerr := os.RemoveAll(c.root); rerr == nil {
 		err = rerr
 	}
 	c.initProcess = nil

--- a/standard_init_linux.go
+++ b/standard_init_linux.go
@@ -47,8 +47,7 @@ func (l *linuxStandardInit) Init() error {
 		return err
 	}
 	label.Init()
-	// InitializeMountNamespace() can be executed only for a new mount namespace
-	if l.config.Config.Namespaces.Contains(configs.NEWNS) {
+	if l.config.Config.Namespaces.Contains(configs.NEWNS) || l.config.Config.Chroot {
 		if err := setupRootfs(l.config.Config, console); err != nil {
 			return err
 		}


### PR DESCRIPTION
**NOTE: This code is basically just a proof of concept.  If the basic approach seems fine I'll produce better code.**

This PR is the libcontainer changes needed to support `--mnt=host` in Docker.  That's right, using the the host mnt namespace.  It might seems crazy, but basically what I'm proposing is that in that situation you do a chroot and not a new mnt namespace.  Before I go into the details of this PR let me first explain why I want this.  That way if this approach is way off then maybe a better one can be proposed.

## Motivation

What I want to accomplish is to allow a container to manage mounts in the host mnt namespace.  The primary use case is to support something like ZFS, LVM, or Ceph that requires userspace utilities to manage.  In RancherOS we have no host system and thus managing such subsystems must be done from a container.  With the recent changes in libcontainer to default to SLAVE we can propagate mount from one container to another through the host using this PR.

My first attempt at this functionality was to just use shared mounts.  I ran into the fundamental issue in that when the container mount namespace is removed all mounts are umounted causing the shared mounts to be removed from the host.  This is no good because we can never restart the container managing the mounts.

## How this PR works

NoPivotRoot is removed and replace with a flag for Chroot.  Here's how Chroot and NEWNS work with each other

NEWNS | Chroot | Behavior | Docker possible?
------|--------|-------|------
NEWNS | false | The default Docker behavior when creating a container | Yep
 - | false | No mount namespace and setupRootFs is not called, so no root | Nope
NEWNS | true | New mnt namespace but we don't pivot_root but instead MS_MOVE and chroot | Yes with DOCKER_RAMDISK=true
- | true | No new mnt namespace but setupRootFs is still called and all mounts are setup | Yep,`--mnt=host`

### Cleanup

When a container is deleted and there is no NEWNS and chroot is true, we must manually remove mounts.  In this situation we traverse mounts in the container and manually umount them all.  **One difference is that we first make the propagation private before we umount.**  This way the mounts are not removed from the host.

fyi @lukemarsden