### PR TITLE
cgroups: Make systemd cgroup parent support use specified slices.

### DIFF
--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -149,8 +149,8 @@ func (m *Manager) Apply(pid int) error {
 		properties []systemd.Property
 	)
 
-	if c.Slice != "" {
-		slice = c.Slice
+	if c.Parent != "" {
+		slice = c.Parent
 	}
 
 	properties = append(properties,
@@ -355,8 +355,8 @@ func getSubsystemPath(c *configs.Cgroup, subsystem string) (string, error) {
 	}
 
 	slice := "system.slice"
-	if c.Slice != "" {
-		slice = c.Slice
+	if c.Parent != "" {
+		slice = c.Parent
 	}
 
 	return filepath.Join(mountpoint, initPath, slice, getUnitName(c)), nil
@@ -420,7 +420,7 @@ func (m *Manager) Set(container *configs.Config) error {
 }
 
 func getUnitName(c *configs.Cgroup) string {
-	return fmt.Sprintf("%s-%s.scope", c.Parent, c.Name)
+	return fmt.Sprintf("%s-%s.scope", c.ScopePrefix, c.Name)
 }
 
 // Atm we can't use the systemd device support because of two missing things:

--- a/configs/cgroup.go
+++ b/configs/cgroup.go
@@ -75,8 +75,8 @@ type Cgroup struct {
 	// set the freeze value for the process
 	Freezer FreezerState `json:"freezer"`
 
-	// Parent slice to use for systemd TODO: remove in favor or parent
-	Slice string `json:"slice"`
+	// prefix for the scope name
+	ScopePrefix string `json:"scope_prefix"`
 
 	// Whether to disable OOM Killer
 	OomKillDisable bool `json:"oom_kill_disable"`

--- a/integration/exec_test.go
+++ b/integration/exec_test.go
@@ -486,7 +486,7 @@ func testCpuShares(t *testing.T, systemd bool) {
 
 	config := newTemplateConfig(rootfs)
 	if systemd {
-		config.Cgroups.Slice = "system.slice"
+		config.Cgroups.Parent = "system.slice"
 	}
 	config.Cgroups.CpuShares = 1
 

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -81,7 +81,7 @@ func copyBusybox(dest string) error {
 func newContainer(config *configs.Config) (libcontainer.Container, error) {
 	f := factory
 
-	if config.Cgroups != nil && config.Cgroups.Slice == "system.slice" {
+	if config.Cgroups != nil && config.Cgroups.Parent == "system.slice" {
 		f = systemdFactory
 	}
 

--- a/nsinit/config.go
+++ b/nsinit/config.go
@@ -28,6 +28,7 @@ var createFlags = []cli.Flag{
 	cli.IntFlag{Name: "memory-swap", Usage: "set the memory swap limit for the container"},
 	cli.StringFlag{Name: "cpuset-cpus", Usage: "set the cpuset cpus"},
 	cli.StringFlag{Name: "cpuset-mems", Usage: "set the cpuset mems"},
+	cli.StringFlag{Name: "cgroup-parent", Usage: "set the cgroup parent"},
 	cli.StringFlag{Name: "apparmor-profile", Usage: "set the apparmor profile"},
 	cli.StringFlag{Name: "process-label", Usage: "set the process label"},
 	cli.StringFlag{Name: "mount-label", Usage: "set the mount label"},
@@ -91,6 +92,11 @@ func modify(config *configs.Config, context *cli.Context) {
 	rootfs := context.String("rootfs")
 	if rootfs != "" {
 		config.Rootfs = rootfs
+	}
+
+	cgroupParent := context.String("cgroup-parent")
+	if cgroupParent != "" {
+		config.Cgroups.Parent = cgroupParent
 	}
 
 	userns_uid := context.Int("userns-root-uid")
@@ -229,7 +235,7 @@ func getTemplate() *configs.Config {
 		}),
 		Cgroups: &configs.Cgroup{
 			Name:            filepath.Base(cwd),
-			Parent:          "nsinit",
+			ScopePrefix:     "nsinit",
 			AllowAllDevices: false,
 			AllowedDevices:  configs.DefaultAllowedDevices,
 		},


### PR DESCRIPTION
Today, we just change the prefix name of the scope file. This PR allows one to specify a slice to use as parent.

Signed-off-by: Mrunal Patel mrunalp@gmail.com
