### PR TITLE
Split namespace syscall content for building on non-Linux

### DIFF
--- a/configs/namespaces.go
+++ b/configs/namespaces.go
@@ -1,9 +1,6 @@
 package configs
 
-import (
-	"fmt"
-	"syscall"
-)
+import "fmt"
 
 type NamespaceType string
 
@@ -32,10 +29,6 @@ func NamespaceTypes() []NamespaceType {
 type Namespace struct {
 	Type NamespaceType `json:"type"`
 	Path string        `json:"path"`
-}
-
-func (n *Namespace) Syscall() int {
-	return namespaceInfo[n.Type]
 }
 
 func (n *Namespace) GetPath(pid int) string {
@@ -95,26 +88,4 @@ func (n *Namespaces) index(t NamespaceType) int {
 
 func (n *Namespaces) Contains(t NamespaceType) bool {
 	return n.index(t) != -1
-}
-
-var namespaceInfo = map[NamespaceType]int{
-	NEWNET:  syscall.CLONE_NEWNET,
-	NEWNS:   syscall.CLONE_NEWNS,
-	NEWUSER: syscall.CLONE_NEWUSER,
-	NEWIPC:  syscall.CLONE_NEWIPC,
-	NEWUTS:  syscall.CLONE_NEWUTS,
-	NEWPID:  syscall.CLONE_NEWPID,
-}
-
-// CloneFlags parses the container's Namespaces options to set the correct
-// flags on clone, unshare. This functions returns flags only for new namespaces.
-func (n *Namespaces) CloneFlags() uintptr {
-	var flag int
-	for _, v := range *n {
-		if v.Path != "" {
-			continue
-		}
-		flag |= namespaceInfo[v.Type]
-	}
-	return uintptr(flag)
 }

--- a/configs/namespaces_syscall.go
+++ b/configs/namespaces_syscall.go
@@ -1,0 +1,31 @@
+// +build linux
+
+package configs
+
+import "syscall"
+
+func (n *Namespace) Syscall() int {
+	return namespaceInfo[n.Type]
+}
+
+var namespaceInfo = map[NamespaceType]int{
+	NEWNET:  syscall.CLONE_NEWNET,
+	NEWNS:   syscall.CLONE_NEWNS,
+	NEWUSER: syscall.CLONE_NEWUSER,
+	NEWIPC:  syscall.CLONE_NEWIPC,
+	NEWUTS:  syscall.CLONE_NEWUTS,
+	NEWPID:  syscall.CLONE_NEWPID,
+}
+
+// CloneFlags parses the container's Namespaces options to set the correct
+// flags on clone, unshare. This functions returns flags only for new namespaces.
+func (n *Namespaces) CloneFlags() uintptr {
+	var flag int
+	for _, v := range *n {
+		if v.Path != "" {
+			continue
+		}
+		flag |= namespaceInfo[v.Type]
+	}
+	return uintptr(flag)
+}

--- a/configs/namespaces_syscall_unsupported.go
+++ b/configs/namespaces_syscall_unsupported.go
@@ -1,0 +1,15 @@
+// +build !linux
+
+package configs
+
+func (n *Namespace) Syscall() int {
+	panic("No namespace syscall support")
+	return 0
+}
+
+// CloneFlags parses the container's Namespaces options to set the correct
+// flags on clone, unshare. This functions returns flags only for new namespaces.
+func (n *Namespaces) CloneFlags() uintptr {
+	panic("No namespace syscall support")
+	return uintptr(0)
+}


### PR DESCRIPTION
libcontainer/configs is used by the docker user namespace proposed
patchset to use IDMap for uid/gid maps across the codebase.  Given the
client uses some of this code, it needs to build on non-Linux.  This
separates out the Linux-only syscalls using build tags.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com> (github: estesp)