### PR TITLE
Remove double cgroup manager initialization.

### DIFF
--- a/factory_linux.go
+++ b/factory_linux.go
@@ -108,7 +108,7 @@ func New(root string, options ...func(*LinuxFactory) error) (Factory, error) {
 		Validator: validate.New(),
 	}
 	InitArgs(os.Args[0], "init")(l)
-	Cgroupfs(l)
+
 	for _, opt := range options {
 		if err := opt(l); err != nil {
 			return nil, err

--- a/nsinit/init.go
+++ b/nsinit/init.go
@@ -16,7 +16,7 @@ var initCommand = cli.Command{
 		log.SetLevel(log.DebugLevel)
 		runtime.GOMAXPROCS(1)
 		runtime.LockOSThread()
-		factory, err := libcontainer.New("")
+		factory, err := libcontainer.New("", libcontainer.Cgroupfs)
 		if err != nil {
 			fatal(err)
 		}


### PR DESCRIPTION
The groups manager should always be provided by the manager.
It looks like this already happened except in the `nsinit init` case.

/cc @crosbymichael

Signed-off-by: David Calavera <david.calavera@gmail.com>