### PR TITLE
add vendor/pkg to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bundles
 nsinit/nsinit
+vendor/pkg


### PR DESCRIPTION
It's auto generated by go install, we should ignore them.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>