### PR TITLE
Do not prevent mounts in /sys

### DIFF
--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -215,7 +215,6 @@ func checkMountDestination(rootfs, dest string) error {
 	}
 	invalidDestinations := []string{
 		"/proc",
-		"/sys",
 	}
 	for _, invalid := range invalidDestinations {
 		path, err := filepath.Rel(filepath.Join(rootfs, invalid), dest)

--- a/rootfs_linux_test.go
+++ b/rootfs_linux_test.go
@@ -15,8 +15,8 @@ func TestCheckMountDestOnProc(t *testing.T) {
 func TestCheckMountDestInSys(t *testing.T) {
 	dest := "/rootfs//sys/fs/cgroup"
 	err := checkMountDestination("/rootfs", dest)
-	if err == nil {
-		t.Fatal("destination inside proc should return an error")
+	if err != nil {
+		t.Fatal("destination inside /sys should not return an error")
 	}
 }
 


### PR DESCRIPTION
Mounts in /sys like /sys/fs/cgroup are valid and should be allowed at
the libcontainer level.

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>