### PR TITLE
Add exceptions for checkMountDest

### DIFF
--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -145,7 +145,7 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 		if dest, err = symlink.FollowSymlinkInScope(filepath.Join(rootfs, m.Destination), rootfs); err != nil {
 			return err
 		}
-		if err := checkMountDestination(rootfs, dest); err != nil {
+		if err := checkMountDest(rootfs, dest); err != nil {
 			return err
 		}
 		if err := createIfNotExists(dest, stat.IsDir()); err != nil {
@@ -206,10 +206,35 @@ func mountToRootfs(m *configs.Mount, rootfs, mountLabel string) error {
 	return nil
 }
 
-// checkMountDestination checks to ensure that the mount destination is not over the
-// top of /proc or /sys.
+func checkSubdirectory(basepath, targpath string) (bool, error) {
+	path, err := filepath.Rel(basepath, targpath)
+	if err != nil {
+		return false, err
+	}
+	if path == "." || !strings.HasPrefix(path, "..") {
+		return true, nil
+	}
+	return false, nil
+}
+
+func checkMountDestException(rootfs, dest string) bool {
+	exceptionDestinations := []string{
+		"/sys/fs/cgroup",
+	}
+
+	for _, exception := range exceptionDestinations {
+		isSub, _ := checkSubdirectory(filepath.Join(rootfs, exception), dest)
+		if isSub {
+			return true
+		}
+	}
+	return false
+}
+
+// checkMountDest checks to ensure that the mount destination is not over the
+// top of /proc or /sys. But we'll have exceptions for certion reasons.
 // dest is required to be an abs path and have any symlinks resolved before calling this function.
-func checkMountDestination(rootfs, dest string) error {
+func checkMountDest(rootfs, dest string) error {
 	if filepath.Clean(rootfs) == filepath.Clean(dest) {
 		return fmt.Errorf("mounting into / is prohibited")
 	}
@@ -218,11 +243,14 @@ func checkMountDestination(rootfs, dest string) error {
 		"/sys",
 	}
 	for _, invalid := range invalidDestinations {
-		path, err := filepath.Rel(filepath.Join(rootfs, invalid), dest)
+		isSub, err := checkSubdirectory(filepath.Join(rootfs, invalid), dest)
 		if err != nil {
 			return err
 		}
-		if path == "." || !strings.HasPrefix(path, "..") {
+		if isSub {
+			if checkMountDestException(rootfs, dest) {
+				continue
+			}
 			return fmt.Errorf("%q cannot be mounted because it is located inside %q", dest, invalid)
 		}
 	}

--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -215,6 +215,7 @@ func checkMountDestination(rootfs, dest string) error {
 	}
 	invalidDestinations := []string{
 		"/proc",
+		"/sys",
 	}
 	for _, invalid := range invalidDestinations {
 		path, err := filepath.Rel(filepath.Join(rootfs, invalid), dest)

--- a/rootfs_linux_test.go
+++ b/rootfs_linux_test.go
@@ -6,23 +6,23 @@ import "testing"
 
 func TestCheckMountDestOnProc(t *testing.T) {
 	dest := "/rootfs/proc/"
-	err := checkMountDestination("/rootfs", dest)
+	err := checkMountDest("/rootfs", dest)
 	if err == nil {
 		t.Fatal("destination inside proc should return an error")
 	}
 }
 
 func TestCheckMountDestInSys(t *testing.T) {
-	dest := "/rootfs//sys/fs/cgroup"
-	err := checkMountDestination("/rootfs", dest)
+	dest := "/rootfs/sys/fs"
+	err := checkMountDest("/rootfs", dest)
 	if err == nil {
-		t.Fatal("destination inside proc should return an error")
+		t.Fatal("destination inside sys should return an error")
 	}
 }
 
 func TestCheckMountDestFalsePositive(t *testing.T) {
 	dest := "/rootfs/sysfiles/fs/cgroup"
-	err := checkMountDestination("/rootfs", dest)
+	err := checkMountDest("/rootfs", dest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -30,8 +30,16 @@ func TestCheckMountDestFalsePositive(t *testing.T) {
 
 func TestCheckMountRoot(t *testing.T) {
 	dest := "/rootfs"
-	err := checkMountDestination("/rootfs", dest)
+	err := checkMountDest("/rootfs", dest)
 	if err == nil {
 		t.Fatal(err)
+	}
+}
+
+func TestCheckMountDestException(t *testing.T) {
+	dest := "/rootfs/sys/fs/cgroup"
+	err := checkMountDest("/rootfs", dest)
+	if err != nil {
+		t.Fatal("/sys/fs/cgroup is an exception, should not fail")
 	}
 }

--- a/rootfs_linux_test.go
+++ b/rootfs_linux_test.go
@@ -15,8 +15,8 @@ func TestCheckMountDestOnProc(t *testing.T) {
 func TestCheckMountDestInSys(t *testing.T) {
 	dest := "/rootfs//sys/fs/cgroup"
 	err := checkMountDestination("/rootfs", dest)
-	if err != nil {
-		t.Fatal("destination inside /sys should not return an error")
+	if err == nil {
+		t.Fatal("destination inside proc should return an error")
 	}
 }
 


### PR DESCRIPTION
We still should prevent mount in /sys for security, special
destionations like /sys/fs/cgroup we can treated as exceptions,
these can be unknown from users for now.

Signed-off-by: Qiang Huang h.huangqiang@huawei.com
