### PR TITLE
AppArmor disable umount & deny proc files.

### DIFF
--- a/apparmor/gen.go
+++ b/apparmor/gen.go
@@ -25,12 +25,15 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
   network,
   capability,
   file,
-  umount,
 
   deny @{PROC}/sys/fs/** wklx,
+  deny @{PROC}/fs/** wklx,
   deny @{PROC}/sysrq-trigger rwklx,
+  deny @{PROC}/timer_stats rwklx,
+  deny @{PROC}/latency_stats rwklx,
   deny @{PROC}/mem rwklx,
   deny @{PROC}/kmem rwklx,
+  deny @{PROC}/kcore rwklx,
   deny @{PROC}/sys/kernel/[^s][^h][^m]* wklx,
   deny @{PROC}/sys/kernel/*/** wklx,
 


### PR DESCRIPTION
If a container cannot mount, it cannot umount.

We should also restrict writing /proc/kcore and the
other paths libcontainer now masks.

This is a less aggressive prelude to #578.

Signed-off-by: Eric Windisch eric@windisch.us
