### PR TITLE
Fix nsenter package on unsupported platforms.

### DIFF
--- a/nsenter/nsenter_unsupported.go
+++ b/nsenter/nsenter_unsupported.go
@@ -1,3 +1,5 @@
 // +build !linux !cgo
 
 package nsenter
+
+import "C"


### PR DESCRIPTION
Commit 4d1d6185abda6a5d43eac75f77242488b81f8937 added this nsenter_unsupported.go file in order for nsenter to be a valid (but empty, non-functional) Go package on unsupported platforms. However, on such platforms, Go still complains because there exists a .c file in this folder, but the package doesn't use cgo.

Fix that by importing "C" pseudo-package.

I don't see any other ways of fixing this, since you can't add build tags to the .c file. But if someone has any additional thoughts here, please comment.

To illustrate the issue, if you are on OS X, which is an unsupported platform, and you do this innocent Go command to update the libcontainer package source to latest version (without building):

```
$ go get -u -d github.com/docker/libcontainer/...
package github.com/docker/libcontainer
	imports github.com/docker/docker/pkg/mount
	imports github.com/docker/libcontainer/cgroups
	imports github.com/docker/libcontainer/configs
	imports github.com/docker/libcontainer/stacktrace
	imports github.com/docker/libcontainer/apparmor
	imports github.com/docker/libcontainer/cgroups/fs
	imports github.com/docker/libcontainer/system
	imports github.com/docker/libcontainer/cgroups/systemd
	imports github.com/docker/libcontainer/configs/validate
	imports github.com/docker/libcontainer/devices
	imports github.com/docker/libcontainer/integration
	imports github.com/docker/libcontainer/label
	imports github.com/docker/libcontainer/netlink
	imports github.com/docker/libcontainer/nsenter
	imports github.com/docker/libcontainer/nsenter
	imports github.com/docker/libcontainer/nsenter: C source files not allowed when not using cgo: nsexec.c
```

Also, if you do:

```
$ go list github.com/docker/libcontainer/nsenter
can't load package: package github.com/docker/libcontainer/nsenter: C source files not allowed when not using cgo: nsexec.c
$ echo $?
1
```

This patch fixes those issues. It should have no affect on platforms where nsenter is supported because I'm only making a change to the `nsenter_unsupported.go` file which is hidden behind `// +build !linux !cgo` builds tags.