### PR TITLE
Add proc mount check for container's config

### DIFF
--- a/configs/validate/config_test.go
+++ b/configs/validate/config_test.go
@@ -1,0 +1,40 @@
+package validate
+
+import (
+	"testing"
+
+	"github.com/docker/libcontainer/configs"
+)
+
+func TestProcMount(t *testing.T) {
+	v := &ConfigValidator{}
+
+	config := &configs.Config{
+		Namespaces: configs.Namespaces{{Type: configs.NEWPID}},
+	}
+	err := v.procMount(config)
+	if err != nil {
+		t.Fatalf("procMount failed to check proc mount")
+	}
+
+	config = &configs.Config{
+		Namespaces: configs.Namespaces{{Type: configs.NEWNS}},
+	}
+	err = v.procMount(config)
+	if err == nil {
+		t.Fatalf("procMount failed to check proc mount")
+	}
+
+	config = &configs.Config{
+		Namespaces: configs.Namespaces{{Type: configs.NEWNS}},
+		Mounts: []*configs.Mount{
+			{Source: "proc",
+				Destination: "/proc",
+			},
+		},
+	}
+	err = v.procMount(config)
+	if err != nil {
+		t.Fatalf("procMount failed to check proc mount")
+	}
+}

--- a/sample_configs/apparmor.json
+++ b/sample_configs/apparmor.json
@@ -5,6 +5,14 @@
 	"rootfs": "/rootfs/jessie",
 	"readonlyfs": false,
 	"mounts": [
+                {
+                        "source": "proc",
+                        "destination": "/proc",
+                        "device": "proc",
+                        "flags": 14,
+                        "data": "",
+                        "relabel": ""
+                },
 		{
 			"source": "shm",
 			"destination": "/dev/shm",

--- a/sample_configs/attach_to_bridge.json
+++ b/sample_configs/attach_to_bridge.json
@@ -5,6 +5,14 @@
 	"rootfs": "/rootfs/jessie",
 	"readonlyfs": false,
 	"mounts": [
+                {
+                        "source": "proc",
+                        "destination": "/proc",
+                        "device": "proc",
+                        "flags": 14,
+                        "data": "",
+                        "relabel": ""
+                },
 		{
 			"source": "shm",
 			"destination": "/dev/shm",

--- a/sample_configs/host-pid.json
+++ b/sample_configs/host-pid.json
@@ -6,6 +6,14 @@
 	"readonlyfs": false,
 	"mounts": [
 		{
+			"source": "proc",
+			"destination": "/proc",
+			"device": "proc",
+			"flags": 14,
+			"data": "",
+			"relabel": ""
+		},
+		{
 			"source": "shm",
 			"destination": "/dev/shm",
 			"device": "tmpfs",

--- a/sample_configs/minimal.json
+++ b/sample_configs/minimal.json
@@ -6,6 +6,14 @@
 	"readonlyfs": false,
 	"mounts": [
 		{
+			"source": "proc",
+			"destination": "/proc",
+			"device": "proc",
+			"flags": 14,
+			"data": "",
+			"relabel": ""
+		},
+		{
 			"source": "shm",
 			"destination": "/dev/shm",
 			"device": "tmpfs",

--- a/sample_configs/selinux.json
+++ b/sample_configs/selinux.json
@@ -5,6 +5,14 @@
 	"rootfs": "/rootfs/jessie",
 	"readonlyfs": false,
 	"mounts": [
+                {
+                        "source": "proc",
+                        "destination": "/proc",
+                        "device": "proc",
+                        "flags": 14,
+                        "data": "",
+                        "relabel": ""
+                },
 		{
 			"source": "shm",
 			"destination": "/dev/shm",

--- a/sample_configs/userns.json
+++ b/sample_configs/userns.json
@@ -5,6 +5,14 @@
 	"rootfs": "/rootfs/jessie",
 	"readonlyfs": false,
 	"mounts": [
+                {
+                        "source": "proc",
+                        "destination": "/proc",
+                        "device": "proc",
+                        "flags": 14,
+                        "data": "",
+                        "relabel": ""
+                },
 		{
 			"source": "shm",
 			"destination": "/dev/shm",


### PR DESCRIPTION
In libcontainer, when we create a new container, it will read some files
in proc filesystem. So if the container config has configured NEWNS
namespace, it must also require the proc mount defined.

This pr add proc mount check in config validate before it really creates a container, 
We also add proc mount for sample configs, then nsinit won't fail to create containers
using these config

Signed-off-by: junxu xujun@cmss.chinamobile.com
