### PR TITLE
Rebased: Additional groups lookup

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -119,7 +119,7 @@ type Config struct {
 
 	// AdditionalGroups specifies the gids that should be added to supplementary groups
 	// in addition to those that the user belongs to.
-	AdditionalGroups []int `json:"additional_groups"`
+	AdditionalGroups []string `json:"additional_groups"`
 
 	// UidMappings is an array of User ID mappings for User Namespaces
 	UidMappings []IDMap `json:"uid_mappings"`

--- a/init_linux.go
+++ b/init_linux.go
@@ -177,10 +177,17 @@ func setupUser(config *initConfig) error {
 	if err != nil {
 		return err
 	}
-	suppGroups := append(execUser.Sgids, config.Config.AdditionalGroups...)
+
+	addGroups, err := user.GetAdditionalGroupsPath(config.Config.AdditionalGroups, groupPath)
+	if err != nil {
+		return err
+	}
+
+	suppGroups := append(execUser.Sgids, addGroups...)
 	if err := syscall.Setgroups(suppGroups); err != nil {
 		return err
 	}
+
 	if err := system.Setgid(execUser.Gid); err != nil {
 		return err
 	}

--- a/nsinit/config.go
+++ b/nsinit/config.go
@@ -46,6 +46,7 @@ var createFlags = []cli.Flag{
 	cli.StringSliceFlag{Name: "bind", Value: &cli.StringSlice{}, Usage: "add bind mounts to the container"},
 	cli.StringSliceFlag{Name: "sysctl", Value: &cli.StringSlice{}, Usage: "set system properties in the container"},
 	cli.StringSliceFlag{Name: "tmpfs", Value: &cli.StringSlice{}, Usage: "add tmpfs mounts to the container"},
+	cli.StringSliceFlag{Name: "groups", Value: &cli.StringSlice{}, Usage: "add additional groups"},
 }
 
 var configCommand = cli.Command{
@@ -113,6 +114,7 @@ func modify(config *configs.Config, context *cli.Context) {
 			node.Gid = uint32(userns_uid)
 		}
 	}
+
 	config.SystemProperties = make(map[string]string)
 	for _, sysProp := range context.StringSlice("sysctl") {
 		parts := strings.SplitN(sysProp, "=", 2)
@@ -121,6 +123,11 @@ func modify(config *configs.Config, context *cli.Context) {
 		}
 		config.SystemProperties[parts[0]] = parts[1]
 	}
+
+	for _, group := range context.StringSlice("groups") {
+		config.AdditionalGroups = append(config.AdditionalGroups, group)
+	}
+
 	for _, rawBind := range context.StringSlice("bind") {
 		mount := &configs.Mount{
 			Device: "bind",


### PR DESCRIPTION
Original PR #559:
> This PR modifies AdditionalGroups to be a string array and the lookup to translate to group ids is performed in the container as discussed in docker/docker#10717
Signed-off-by: Mrunal Patel mrunalp@gmail.com

This carries #559, did a rebase and implement the group lookup by scanning through the group file only once.

@mrunalp Can you take a look if this looks good ? I cant open the PR back to the original because of the rebase.