### PR TITLE
Process.go can compile on FreeBSD

### DIFF
--- a/console_freebsd.go
+++ b/console_freebsd.go
@@ -1,0 +1,13 @@
+// +build freebsd
+
+package libcontainer
+
+import (
+	"errors"
+)
+
+// newConsole returns an initalized console that can be used within a container by copying bytes
+// from the master side to the slave that is attached as the tty for the container's init process.
+func newConsole(uid, gid int) (Console, error) {
+	return nil, errors.New("libcontainer console is not supported on FreeBSD")
+}


### PR DESCRIPTION
Whan trying to compile docker on FreeBSD, i'm recieving build error because console functions are implemented for linux only. Created a stub to silence this.