### PR TITLE
bug fix: slice bounds out of range

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -21,6 +21,9 @@ func GenerateRandomName(prefix string, size int) (string, error) {
 	if _, err := io.ReadFull(rand.Reader, id); err != nil {
 		return "", err
 	}
+	if size > 64 {
+		size = 64
+	}
 	return prefix + hex.EncodeToString(id)[:size], nil
 }
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -9,7 +9,17 @@ func TestGenerateName(t *testing.T) {
 	}
 
 	expected := 5 + len("veth")
-	if len(name) != 5+len("veth") {
+	if len(name) != expected {
+		t.Fatalf("expected name to be %d chars but received %d", expected, len(name))
+	}
+
+	name, err = GenerateRandomName("veth", 65)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected = 64 + len("veth")
+	if len(name) != expected {
 		t.Fatalf("expected name to be %d chars but received %d", expected, len(name))
 	}
 }


### PR DESCRIPTION
If TestGenerateName() accept size parameter larger than 64, it will panic.
This patch fix this potential panic bug.

Signed-off-by: Zhang Wei <zhangwei555@huawei.com>