### PR TITLE
A container can join pid namespace of another container.

### DIFF
--- a/configs/namespaces_unix.go
+++ b/configs/namespaces_unix.go
@@ -2,7 +2,11 @@
 
 package configs
 
-import "fmt"
+import (
+	"fmt"
+	"os"
+	"sync"
+)
 
 const (
 	NEWNET  NamespaceType = "NEWNET"
@@ -12,6 +16,52 @@ const (
 	NEWIPC  NamespaceType = "NEWIPC"
 	NEWUSER NamespaceType = "NEWUSER"
 )
+
+var (
+	nsLock              sync.Mutex
+	supportedNamespaces = make(map[NamespaceType]bool)
+)
+
+// nsToFile converts the namespace type to its filename
+func nsToFile(ns NamespaceType) string {
+	switch ns {
+	case NEWNET:
+		return "net"
+	case NEWNS:
+		return "mnt"
+	case NEWPID:
+		return "pid"
+	case NEWIPC:
+		return "ipc"
+	case NEWUSER:
+		return "user"
+	case NEWUTS:
+		return "uts"
+	}
+	return ""
+}
+
+// IsNamespaceSupported returns the list of current kernel's supported
+// namespaces. The namespaces will be sorted in order that we can safely setns
+// to (i.e., mount namespace is at the bottom of the list)
+func IsNamespaceSupported(ns NamespaceType) bool {
+	nsLock.Lock()
+	defer nsLock.Unlock()
+	supported, ok := supportedNamespaces[ns]
+	if ok {
+		return supported
+	}
+	nsFile := nsToFile(ns)
+	// if the namespace type is unknown, just return false
+	if nsFile == "" {
+		return false
+	}
+	_, err := os.Stat(fmt.Sprintf("/proc/self/ns/%s", nsFile))
+	// a namespace is supported if it exists and we have permissions to read it
+	supported = err == nil
+	supportedNamespaces[ns] = supported
+	return supported
+}
 
 func NamespaceTypes() []NamespaceType {
 	return []NamespaceType{
@@ -35,26 +85,7 @@ func (n *Namespace) GetPath(pid int) string {
 	if n.Path != "" {
 		return n.Path
 	}
-	return fmt.Sprintf("/proc/%d/ns/%s", pid, n.file())
-}
-
-func (n *Namespace) file() string {
-	file := ""
-	switch n.Type {
-	case NEWNET:
-		file = "net"
-	case NEWNS:
-		file = "mnt"
-	case NEWPID:
-		file = "pid"
-	case NEWIPC:
-		file = "ipc"
-	case NEWUSER:
-		file = "user"
-	case NEWUTS:
-		file = "uts"
-	}
-	return file
+	return fmt.Sprintf("/proc/%d/ns/%s", pid, nsToFile(n.Type))
 }
 
 func (n *Namespaces) Remove(t NamespaceType) bool {

--- a/container_linux.go
+++ b/container_linux.go
@@ -821,14 +821,14 @@ func (c *linuxContainer) currentState() (*State, error) {
 func orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string, error) {
 	paths := []string{}
 	for _, nsType := range []configs.NamespaceType{
-		// TODO: enable configs.NEWUSER,
 		configs.NEWIPC,
 		configs.NEWUTS,
 		configs.NEWNET,
 		configs.NEWPID,
-		// mnt namespace must be the last one. After switching to mnt
-		// namespace, the old /proc will be inaccessible.
 		configs.NEWNS,
+		// user namespace must be the last one because we need enough privilege
+		// to setns
+		configs.NEWUSER,
 	} {
 		if p, ok := namespaces[nsType]; ok && p != "" {
 			// check if the requested namespace is supported

--- a/container_linux.go
+++ b/container_linux.go
@@ -831,9 +831,18 @@ func orderNamespacePaths(namespaces map[configs.NamespaceType]string) ([]string,
 		configs.NEWNS,
 	} {
 		if p, ok := namespaces[nsType]; ok && p != "" {
+			// check if the requested namespace is supported
+			if !configs.IsNamespaceSupported(nsType) {
+				return nil, newSystemError(fmt.Errorf("namespace %s is not supported", nsType))
+			}
 			// only set to join this namespace if it exists
 			if _, err := os.Lstat(p); err != nil {
 				return nil, newSystemError(err)
+			}
+			// do not allow namespace path with comma as we use it to separate
+			// the namespace paths
+			if strings.ContainsRune(p, ',') {
+				return nil, newSystemError(fmt.Errorf("invalid path %s", p))
 			}
 			paths = append(paths, p)
 		}

--- a/init_linux.go
+++ b/init_linux.go
@@ -138,25 +138,6 @@ func finalizeNamespace(config *initConfig) error {
 	return nil
 }
 
-// joinExistingNamespaces gets all the namespace paths specified for the container and
-// does a setns on the namespace fd so that the current process joins the namespace.
-func joinExistingNamespaces(namespaces []configs.Namespace) error {
-	for _, ns := range namespaces {
-		if ns.Path != "" {
-			f, err := os.OpenFile(ns.Path, os.O_RDONLY, 0)
-			if err != nil {
-				return err
-			}
-			err = system.Setns(f.Fd(), uintptr(ns.Syscall()))
-			f.Close()
-			if err != nil {
-				return err
-			}
-		}
-	}
-	return nil
-}
-
 // setupUser changes the groups, gid, and uid for the user inside the container
 func setupUser(config *initConfig) error {
 	// Set up defaults.

--- a/integration/execin_test.go
+++ b/integration/execin_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/docker/libcontainer"
+	"github.com/docker/libcontainer/configs"
 )
 
 func TestExecIn(t *testing.T) {
@@ -330,5 +332,61 @@ func TestExecinPassExtraFiles(t *testing.T) {
 	out2 := string(buf)
 	if out2 != "2" {
 		t.Fatalf("expected second pipe to receive '2', got '%s'", out2)
+	}
+}
+
+func TestExecInUserns(t *testing.T) {
+	if _, err := os.Stat("/proc/self/ns/user"); os.IsNotExist(err) {
+		t.Skip("userns is unsupported")
+	}
+	if testing.Short() {
+		return
+	}
+	rootfs, err := newRootfs()
+	ok(t, err)
+	defer remove(rootfs)
+	config := newTemplateConfig(rootfs)
+	config.UidMappings = []configs.IDMap{{0, 0, 1000}}
+	config.GidMappings = []configs.IDMap{{0, 0, 1000}}
+	config.Namespaces = append(config.Namespaces, configs.Namespace{Type: configs.NEWUSER})
+	container, err := newContainer(config)
+	ok(t, err)
+	defer container.Destroy()
+
+	// Execute a first process in the container
+	stdinR, stdinW, err := os.Pipe()
+	ok(t, err)
+	process := &libcontainer.Process{
+		Args:  []string{"cat"},
+		Env:   standardEnvironment,
+		Stdin: stdinR,
+	}
+	err = container.Start(process)
+	stdinR.Close()
+	defer stdinW.Close()
+	ok(t, err)
+
+	initPID, err := process.Pid()
+	ok(t, err)
+	initUserns, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/user", initPID))
+	ok(t, err)
+
+	buffers := newStdBuffers()
+	process2 := &libcontainer.Process{
+		Args: []string{"readlink", "/proc/self/ns/user"},
+		Env: []string{
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+		},
+		Stdout: buffers.Stdout,
+		Stderr: buffers.Stderr,
+	}
+	err = container.Start(process2)
+	ok(t, err)
+	waitProcess(process2, t)
+	stdinW.Close()
+	waitProcess(process, t)
+
+	if out := strings.TrimSpace(buffers.Stdout.String()); out != initUserns {
+		t.Errorf("execin userns(%s), wanted %s", out, initUserns)
 	}
 }

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -92,13 +92,15 @@ func copyBusybox(dest string) error {
 }
 
 func newContainer(config *configs.Config) (libcontainer.Container, error) {
-	f := factory
+	return newContainerName("testCT", config)
+}
 
+func newContainerName(name string, config *configs.Config) (libcontainer.Container, error) {
+	f := factory
 	if config.Cgroups != nil && config.Cgroups.Slice == "system.slice" {
 		f = systemdFactory
 	}
-
-	return f.Create("testCT", config)
+	return f.Create(name, config)
 }
 
 // runContainer runs the container with the specific config and arguments

--- a/nsinit/config.go
+++ b/nsinit/config.go
@@ -93,6 +93,11 @@ func modify(config *configs.Config, context *cli.Context) {
 	config.ProcessLabel = context.String("process-label")
 	config.MountLabel = context.String("mount-label")
 
+	// if we use a custom id for nsinit, then use that id as cgroups' name
+	if cid := context.String("id"); cid != "" {
+		config.Cgroups.Name = cid
+	}
+
 	rootfs := context.String("rootfs")
 	if rootfs != "" {
 		config.Rootfs = rootfs

--- a/standard_init_linux.go
+++ b/standard_init_linux.go
@@ -18,10 +18,6 @@ type linuxStandardInit struct {
 }
 
 func (l *linuxStandardInit) Init() error {
-	// join any namespaces via a path to the namespace fd if provided
-	if err := joinExistingNamespaces(l.config.Config.Namespaces); err != nil {
-		return err
-	}
 	var console *linuxConsole
 	if l.config.Console != "" {
 		console = newConsoleFromPath(l.config.Console)


### PR DESCRIPTION
Fix #604 

This supports setting `configs.NEWPID` to an existing PID namespace for a container's init process. It leverages the same C code infrastructure for `execin` to clone a new init process with the wanted PID namespace.

Edit: Because of some sharing in code between init and execin, execin also supports joining userns of the init process now. Init process cant join mnt/userns of another init process yet.
