### PR TITLE
linux_container: fix error handling in start

### DIFF
--- a/container_linux.go
+++ b/container_linux.go
@@ -106,8 +106,8 @@ func (c *linuxContainer) Start(process *Process) error {
 	}
 	if err := parent.start(); err != nil {
 		// terminate the process to ensure that it properly is reaped.
-		if err := parent.terminate(); err != nil {
-			logrus.Warn(err)
+		if terr := parent.terminate(); terr != nil {
+			logrus.Warn(terr)
 		}
 		return newSystemError(err)
 	}


### PR DESCRIPTION
if parent.terminate goes OK we will never know about parent.start error

Signed-off-by: Pavel Tikhomirov <snorcht@gmail.com>