### PR TITLE
Update dockerproject.com links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## libcontainer - reference implementation for containers [![Build Status](https://jenkins.dockerproject.com/buildStatus/icon?job=Libcontainer Master)](https://jenkins.dockerproject.com/job/Libcontainer%20Master/)
+## libcontainer - reference implementation for containers [![Build Status](https://jenkins.dockerproject.org/buildStatus/icon?job=Libcontainer%20Master)](https://jenkins.dockerproject.org/job/Libcontainer%20Master/)
 
 Libcontainer provides a native Go implementation for creating containers
 with namespaces, cgroups, capabilities, and filesystem access controls.


### PR DESCRIPTION
The dockerproject.com domain is moving to dockerproject.org this changes the buildstatus link to point to the new domain.

For reference, see https://github.com/docker/docker/pull/13709
