### PR TITLE
make libcontainer compile on freebsd (again)

### DIFF
--- a/configs/config_unix.go
+++ b/configs/config_unix.go
@@ -1,3 +1,5 @@
+// +build freebsd linux
+
 package configs
 
 import "fmt"

--- a/configs/device_defaults.go
+++ b/configs/device_defaults.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux freebsd
 
 package configs
 

--- a/configs/namespaces_unix.go
+++ b/configs/namespaces_unix.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux freebsd
 
 package configs
 

--- a/devices/devices_unix.go
+++ b/devices/devices_unix.go
@@ -1,3 +1,5 @@
+// +build linux freebsd
+
 package devices
 
 import (

--- a/devices/number.go
+++ b/devices/number.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux freebsd
 
 package devices
 

--- a/stats_freebsd.go
+++ b/stats_freebsd.go
@@ -1,0 +1,5 @@
+package libcontainer
+
+type Stats struct {
+	Interfaces []*NetworkInterface
+}

--- a/system/sysconfig.go
+++ b/system/sysconfig.go
@@ -1,4 +1,4 @@
-// +build cgo,linux
+// +build cgo,linux cgo,freebsd
 
 package system
 


### PR DESCRIPTION
Libcontainer codebase has changed, fixing broken FreeBSD build.