### PR TITLE
Stop systemd unit on destroy

### DIFF
--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -259,6 +259,7 @@ func (m *Manager) Apply(pid int) error {
 func (m *Manager) Destroy() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	theConn.StopUnit(getUnitName(m.Cgroups), "replace")
 	if err := cgroups.RemovePaths(m.Paths); err != nil {
 		return err
 	}


### PR DESCRIPTION
It totally fixes leftover ".scope" fails. Of course it's just
workaround, real issue seems to be in go-systemd library or in systemd
itself.
I tried latest commit from `coreos/go-systemd` and it has same issue.
ping @philips looks okay for you as workaround?