### PR TITLE
linux: Convert dup2 calls to dup3

### DIFF
--- a/console_linux.go
+++ b/console_linux.go
@@ -92,7 +92,7 @@ func (c *linuxConsole) mount(rootfs, mountLabel string, uid, gid int) error {
 	return syscall.Mount(c.slavePath, dest, "bind", syscall.MS_BIND, "")
 }
 
-// dupStdio opens the slavePath for the console and dup2s the fds to the current
+// dupStdio opens the slavePath for the console and dups the fds to the current
 // processes stdio, fd 0,1,2.
 func (c *linuxConsole) dupStdio() error {
 	slave, err := c.open(syscall.O_RDWR)
@@ -101,7 +101,7 @@ func (c *linuxConsole) dupStdio() error {
 	}
 	fd := int(slave.Fd())
 	for _, i := range []int{0, 1, 2} {
-		if err := syscall.Dup2(fd, i); err != nil {
+		if err := syscall.Dup3(fd, i, 0); err != nil {
 			return err
 		}
 	}

--- a/nsenter/nsexec.c
+++ b/nsenter/nsexec.c
@@ -148,15 +148,15 @@ void nsexec()
 				pr_perror("ioctl TIOCSCTTY failed");
 				exit(1);
 			}
-			if (dup2(consolefd, STDIN_FILENO) != STDIN_FILENO) {
+			if (dup3(consolefd, STDIN_FILENO, 0) != STDIN_FILENO) {
 				pr_perror("Failed to dup 0");
 				exit(1);
 			}
-			if (dup2(consolefd, STDOUT_FILENO) != STDOUT_FILENO) {
+			if (dup3(consolefd, STDOUT_FILENO, 0) != STDOUT_FILENO) {
 				pr_perror("Failed to dup 1");
 				exit(1);
 			}
-			if (dup2(consolefd, STDERR_FILENO) != STDERR_FILENO) {
+			if (dup3(consolefd, STDERR_FILENO, 0) != STDERR_FILENO) {
 				pr_perror("Failed to dup 2");
 				exit(1);
 			}

--- a/rootfs_linux.go
+++ b/rootfs_linux.go
@@ -272,7 +272,7 @@ func reOpenDevNull(rootfs string) error {
 		}
 		if stat.Rdev == devNullStat.Rdev {
 			// Close and re-open the fd.
-			if err := syscall.Dup2(int(file.Fd()), fd); err != nil {
+			if err := syscall.Dup3(int(file.Fd()), fd, 0); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
Convert syscall.Dup2 calls to syscall.Dup3.  The dup2 syscall is depreciated
and is not available on some architectures.  Fixes build errors like these when
building for arm64:

  console_linux.go: undefined: syscall.Dup2

Signed-off-by: Geoff Levand <geoff@infradead.org>