### PR TITLE
Fix relabel to allow volume mounting of /

### DIFF
--- a/label/label_selinux.go
+++ b/label/label_selinux.go
@@ -105,13 +105,13 @@ func Relabel(path string, fileLabel string, relabel string) error {
 	if fileLabel == "" {
 		return nil
 	}
+	if !strings.ContainsAny(relabel, "zZ") {
+		return nil
+	}
 	for _, p := range exclude_path {
 		if path == p {
 			return fmt.Errorf("Relabeling of %s is not allowed", path)
 		}
-	}
-	if !strings.ContainsAny(relabel, "zZ") {
-		return nil
 	}
 	if strings.Contains(relabel, "z") && strings.Contains(relabel, "Z") {
 		return fmt.Errorf("Bad SELinux option z and Z can not be used together")


### PR DESCRIPTION
Current libcontainer in docker-1.7 will not allow you to volume mount /, /etc, and /usr into a container.  You even if you have not asked SElinux to relabel.  This patch will allow you to mount if you did not ask to relabel.

Needs to be cherrypicked into your docker-1.7 release.

Docker-DCO-1.1-Signed-off-by: Dan Walsh <dwalsh@redhat.com> (github: rhatdan)
