### PR TITLE
Don't change memswap value in libcontainer

### DIFF
--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -46,12 +46,6 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 			return err
 		}
 	}
-	// By default, MemorySwap is set to twice the size of Memory.
-	if cgroup.MemorySwap == 0 && cgroup.Memory != 0 {
-		if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(cgroup.Memory*2, 10)); err != nil {
-			return err
-		}
-	}
 	if cgroup.MemorySwap > 0 {
 		if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(cgroup.MemorySwap, 10)); err != nil {
 			return err

--- a/cgroups/fs/memory_test.go
+++ b/cgroups/fs/memory_test.go
@@ -85,35 +85,6 @@ func TestMemorySetMemoryswap(t *testing.T) {
 	}
 }
 
-func TestMemorySetMemoryswapDefault(t *testing.T) {
-	helper := NewCgroupTestUtil("memory", t)
-	defer helper.cleanup()
-
-	const (
-		memoryBefore    = 209715200 // 200M
-		memoryAfter     = 314572800 // 300M
-		memoryswapAfter = 629145600 // 300M*2
-	)
-
-	helper.writeFileContents(map[string]string{
-		"memory.limit_in_bytes": strconv.Itoa(memoryBefore),
-	})
-
-	helper.CgroupData.c.Memory = memoryAfter
-	memory := &MemoryGroup{}
-	if err := memory.Set(helper.CgroupPath, helper.CgroupData.c); err != nil {
-		t.Fatal(err)
-	}
-
-	value, err := getCgroupParamUint(helper.CgroupPath, "memory.memsw.limit_in_bytes")
-	if err != nil {
-		t.Fatalf("Failed to parse memory.memsw.limit_in_bytes - %s", err)
-	}
-	if value != memoryswapAfter {
-		t.Fatal("Got the wrong value, set memory.memsw.limit_in_bytes failed.")
-	}
-}
-
 func TestMemorySetKernelMemory(t *testing.T) {
 	helper := NewCgroupTestUtil("memory", t)
 	defer helper.cleanup()

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -469,14 +469,8 @@ func joinMemory(c *configs.Cgroup, pid int) error {
 	}
 
 	// -1 disables memoryswap
-	if c.Memory != 0 && c.MemorySwap >= 0 {
-		memorySwap := c.MemorySwap
-
-		if memorySwap == 0 {
-			// By default, MemorySwap is set to twice the size of RAM.
-			memorySwap = c.Memory * 2
-		}
-		err = writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(memorySwap, 10))
+	if c.MemorySwap > 0 {
+		err = writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(c.MemorySwap, 10))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As discussed in https://github.com/docker/libcontainer/issues/616,
remove this logic in libcontainer.

Signed-off-by: Qiang Huang <h.huangqiang@huawei.com>