### PR TITLE
Additional ppc architectures follow the arm datatype

### DIFF
--- a/netlink/netlink_linux_armppc64.go
+++ b/netlink/netlink_linux_armppc64.go
@@ -1,3 +1,5 @@
+// +build arm ppc64 ppc64le
+
 package netlink
 
 func ifrDataByte(b byte) uint8 {

--- a/netlink/netlink_linux_notarm.go
+++ b/netlink/netlink_linux_notarm.go
@@ -1,4 +1,4 @@
-// +build !arm
+// +build !arm,!ppc64,!ppc64le
 
 package netlink
 


### PR DESCRIPTION
Proposed fix for https://github.com/docker/docker/issues/13856
ppc64 & ppc64le share the same return data type as the arm architecture for the ifrDataByte call.
This change adds build tags to implement that change. 

Signed-off-by: Michael Chase-Salerno <bratac@linux.vnet.ibm.com>