### PR TITLE
init_linux: Inject the incoming UID (-u) into /etc/passwd

### DIFF
--- a/init_linux.go
+++ b/init_linux.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -112,6 +113,12 @@ func finalizeNamespace(config *initConfig) error {
 	if err != nil {
 		return err
 	}
+
+	// inject /etc/passwd until we have sufficient privs to do that
+	if err := injectUserPasswd(config); err != nil {
+		return err
+	}
+
 	// drop capabilities in bounding set before changing user
 	if err := w.dropBoundingSet(); err != nil {
 		return err
@@ -135,6 +142,66 @@ func finalizeNamespace(config *initConfig) error {
 			return err
 		}
 	}
+	return nil
+}
+
+func injectUserPasswd(config *initConfig) error {
+	if config.User == "" {
+		return nil
+	}
+
+	var (
+		suid, sgid string
+		uid        int
+	)
+
+	parts := strings.Split(config.User, ":")
+	switch len(parts) {
+	/* UID alone */
+	case 1:
+		if numid, err := strconv.Atoi(config.User); err != nil {
+			return nil
+		} else {
+			uid = numid
+		}
+		suid = config.User
+		sgid = suid
+		break
+	case 2:
+		if _, err := strconv.Atoi(parts[0]); err != nil {
+			return nil
+		}
+		suid = parts[0]
+		sgid = suid
+
+		if _, err := strconv.Atoi(parts[1]); err == nil {
+			sgid = parts[1]
+		}
+
+	default:
+		return nil
+	}
+
+	if pf, err := user.GetPasswd(); err == nil {
+		defer pf.Close()
+
+		found, err := user.ParsePasswdFilter(pf, func(u user.User) bool {
+			return u.Name == "DockerUser" || u.Uid == uid
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if len(found) == 0 {
+			/* No DockerUser in /etc/passwd - define one */
+			if fp, err := os.OpenFile("/etc/passwd", os.O_WRONLY|os.O_APPEND, os.FileMode(0666)); err == nil {
+				fp.WriteString(fmt.Sprintf("%s:x:%s:%s:Docker Mapped User:/:/sbin/nologin\n", "DockerUser", suid, sgid))
+				fp.Close()
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -200,6 +267,7 @@ func setupUser(config *initConfig) error {
 			return err
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This patch inserts the incoming `UID`/`GID` specified on the command line as:

`docker run -u 1234 image`

into `/etc/passwd` under the following circumstances:

1) The file already exists
2) `DockerUser` is not defined in the file
3) The incoming `UID` does not belong to any user as specified in the file

The rationale is that it's rather common idiom to use `getpwent()` and the like to get information about the `UID`, which fails if the user record is not present in the file, causing programs like `postgresql` to not work at all under a random `UID`.

Signed-off-by: Pavel Odvody podvody@redhat.com
