### PR TITLE
Propogate container's mountpoint to the host

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -72,8 +72,11 @@ type Config struct {
 	// bind mounts are writtable.
 	Readonlyfs bool `json:"readonlyfs"`
 
-	// Privatefs will mount the container's rootfs as private where mount points from the parent will not propogate
-	Privatefs bool `json:"privatefs"`
+	// RootMount is the rootfs mount mode, it is one of the followings:
+	// "private": rootfs is mounted as MS_PRIVATE
+	// "shared":  rootfs is mounted as MS_SHARED
+	// "slave":   rootfs is mounted as MS_SLAVE
+	RootMount string `json:"root_mount"`
 
 	// Mounts specify additional source and destination paths that will be mounted inside the container's
 	// rootfs and mount namespace if specified


### PR DESCRIPTION
Current a container has to nsenter the host's mount namespace to mount filesystem and
share with other containers. This approach doesn't work if the filesystem mount
calls helper utility (/sbin/mount.XXX). This limitation makes [containerized kubelet](https://github.com/GoogleCloudPlatform/kubernetes/issues/6848) unable to mount certain filesystems.

This commit provides a new flag to make rootfs sharable. Since moving a shared rootfs is semantically confusing for `pivot_root(2)` and `MS_MOVE`. A new function `changeRoot()` is provided to switch rootfs to new destination.

Signed-off-by: Huamin Chen hchen@redhat.com
