### PR TITLE
Fix some suspicious things in vendor

### DIFF
--- a/hack/validate.sh
+++ b/hack/validate.sh
@@ -9,7 +9,7 @@ validate() {
     bash /go/src/github.com/docker/docker/hack/make/validate-dco
     bash /go/src/github.com/docker/docker/hack/make/validate-gofmt
     go get golang.org/x/tools/cmd/vet
-    go vet github.com/docker/libcontainer/...
+    bash /go/src/github.com/docker/docker/hack/make/validate-vet
 }
 
 # run validations

--- a/update-vendor.sh
+++ b/update-vendor.sh
@@ -44,7 +44,7 @@ clone git github.com/codegangsta/cli 1.1.0
 clone git github.com/coreos/go-systemd v2
 clone git github.com/godbus/dbus v2
 clone git github.com/Sirupsen/logrus v0.7.3
-clone git github.com/syndtr/gocapability 8e4cdcb
+clone git github.com/syndtr/gocapability 66ef2aa
 clone git github.com/golang/protobuf 655cdfa588ea
 
 # intentionally not vendoring Docker itself...  that'd be a circle :)

--- a/vendor/src/github.com/golang/protobuf/proto/all_test.go
+++ b/vendor/src/github.com/golang/protobuf/proto/all_test.go
@@ -1281,9 +1281,7 @@ func TestEnum(t *testing.T) {
 // We don't care what the value actually is, just as long as it doesn't crash.
 func TestPrintingNilEnumFields(t *testing.T) {
 	pb := new(GoEnum)
-	if fmt.Sprintf("%+v", pb) == "" {
-		t.Errorf("expected non-empty string")
-	}
+	fmt.Sprintf("%+v", pb)
 }
 
 // Verify that absent required fields cause Marshal/Unmarshal to return errors.


### PR DESCRIPTION
I changed hash for gocapability and re-run vendor script. Also I change vet validation to use docker version, which run vet only on changed files to skip `golang/protobuf` warning.
We discovered those issues in #633 