### PR TITLE
Avoid trying to access cpu.shares when it doesn't exist

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -304,6 +304,10 @@ func removePath(p string, err error) error {
 func CheckCpushares(path string, c int64) error {
 	var cpuShares int64
 
+	if c == 0 {
+		return nil
+	}
+
 	fd, err := os.Open(filepath.Join(path, "cpu.shares"))
 	if err != nil {
 		return err
@@ -314,12 +318,11 @@ func CheckCpushares(path string, c int64) error {
 	if err != nil && err != io.EOF {
 		return err
 	}
-	if c != 0 {
-		if c > cpuShares {
-			return fmt.Errorf("The maximum allowed cpu-shares is %d", cpuShares)
-		} else if c < cpuShares {
-			return fmt.Errorf("The minimum allowed cpu-shares is %d", cpuShares)
-		}
+
+	if c > cpuShares {
+		return fmt.Errorf("The maximum allowed cpu-shares is %d", cpuShares)
+	} else if c < cpuShares {
+		return fmt.Errorf("The minimum allowed cpu-shares is %d", cpuShares)
 	}
 
 	return nil


### PR DESCRIPTION
Even if cpu cgroup controller is enabled it's still possible that
cpu.shares doesn't exist.

This is the case when the kernel config has CONFIG_CGROUP_SCHED
enabled but CONFIG_FAIR_GROUP_SCHED disabled. Then docker fails to
start containers even --cpu-shares isn't specified.

$ sudo docker run -i -t ubuntu:14.04
Error response from daemon: Cannot start container 5600ae87eb9d0eca49f6bcee012247d6b4beb49c426d6cf17e2456279f9311f6: [8] System error: open /sys/fs/cgroup/cpu/docker/5600ae87eb9d0eca49f6bcee012247d6b4beb49c426d6cf17e2456279f9311f6/cpu.shares: no such file or directory

Signed-off-by: Zefan Li <lizefan@huawei.com>