### PR TITLE
Ensure all parent dirs are properly setup

### DIFF
--- a/cgroups/fs/cpuset.go
+++ b/cgroups/fs/cpuset.go
@@ -21,7 +21,6 @@ func (s *CpusetGroup) Apply(d *data) error {
 	if err != nil && !cgroups.IsNotFound(err) {
 		return err
 	}
-
 	return s.ApplyDir(dir, d.c, d.pid)
 }
 
@@ -31,13 +30,11 @@ func (s *CpusetGroup) Set(path string, cgroup *configs.Cgroup) error {
 			return err
 		}
 	}
-
 	if cgroup.CpusetMems != "" {
 		if err := writeFile(path, "cpuset.mems", cgroup.CpusetMems); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
@@ -55,10 +52,13 @@ func (s *CpusetGroup) ApplyDir(dir string, cgroup *configs.Cgroup, pid int) erro
 	if dir == "" {
 		return nil
 	}
-	if err := s.ensureParent(dir); err != nil {
+	root, err := getCgroupRoot()
+	if err != nil {
 		return err
 	}
-
+	if err := s.ensureParent(dir, root); err != nil {
+		return err
+	}
 	// because we are not using d.join we need to place the pid into the procs file
 	// unlike the other subsystems
 	if err := writeFile(dir, "cgroup.procs", strconv.Itoa(pid)); err != nil {
@@ -84,22 +84,17 @@ func (s *CpusetGroup) getSubsystemSettings(parent string) (cpus []byte, mems []b
 	return cpus, mems, nil
 }
 
-// ensureParent ensures that the parent directory of current is created
-// with the proper cpus and mems files copied from it's parent if the values
-// are a file with a new line char
-func (s *CpusetGroup) ensureParent(current string) error {
+// ensureParent makes sure that the parent directory of current is created
+// and populated with the proper cpus and mems files copied from
+// it's parent.
+func (s *CpusetGroup) ensureParent(current, root string) error {
 	parent := filepath.Dir(current)
-
-	if _, err := os.Stat(parent); err != nil {
-		if !os.IsNotExist(err) {
-			return err
-		}
-
-		if err := s.ensureParent(parent); err != nil {
-			return err
-		}
+	if filepath.Clean(parent) == root {
+		return nil
 	}
-
+	if err := s.ensureParent(parent, root); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(current, 0755); err != nil && !os.IsExist(err) {
 		return err
 	}


### PR DESCRIPTION
Even if libcontainer does not create the directories for the cpuset
cgroup we should ensure that they are properly populated with the
parent's cpus and mems values.  Some systems create the directory
structures but do not correctly populate the values and causes our
implementation to fail.

The change in this code is that instead of stopping when we find the first parent directory in `cpuset`, we keep moving up the hierarchy until we hit the root of the `cpuset` cgroup to ensure that every parent is correctly created. 

Signed-off-by: Michael Crosby <crosbymichael@gmail.com>