### PR TITLE
Make TestParseCgroups more complete

### DIFF
--- a/cgroups/cgroups_test.go
+++ b/cgroups/cgroups_test.go
@@ -22,8 +22,17 @@ const (
 
 func TestParseCgroups(t *testing.T) {
 	r := bytes.NewBuffer([]byte(cgroupsContents))
-	_, err := ParseCgroupFile("blkio", r)
+
+	dir, err := ParseCgroupFile("blkio", r)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if dir != "/" {
+		t.Fatal(err)
+	}
+
+	dir, err = ParseCgroupFile("foo", r)
+	if err == nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
- Check the dir returned by ParseCgroupFile()
- Test if ParseCgroupFile() can handle non-existing subsystem properly

Signed-off-by: Zefan Li lizefan@huawei.com
