### PR TITLE
cgroups: fs: fix issues with .Apply()

### DIFF
--- a/cgroups/fs/blkio.go
+++ b/cgroups/fs/blkio.go
@@ -19,7 +19,10 @@ type BlkioGroup struct {
 
 func (s *BlkioGroup) Apply(d *data) error {
 	dir, err := d.join("blkio")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/cgroups/fs/cpu.go
+++ b/cgroups/fs/cpu.go
@@ -19,7 +19,10 @@ func (s *CpuGroup) Apply(d *data) error {
 	// We always want to join the cpu group, to allow fair cpu scheduling
 	// on a container basis
 	dir, err := d.join("cpu")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/cgroups/fs/cpuset.go
+++ b/cgroups/fs/cpuset.go
@@ -18,7 +18,10 @@ type CpusetGroup struct {
 
 func (s *CpusetGroup) Apply(d *data) error {
 	dir, err := d.path("cpuset")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	return s.ApplyDir(dir, d.c, d.pid)

--- a/cgroups/fs/freezer.go
+++ b/cgroups/fs/freezer.go
@@ -16,7 +16,10 @@ type FreezerGroup struct {
 
 func (s *FreezerGroup) Apply(d *data) error {
 	dir, err := d.join("freezer")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/cgroups/fs/hugetlb.go
+++ b/cgroups/fs/hugetlb.go
@@ -16,7 +16,10 @@ type HugetlbGroup struct {
 
 func (s *HugetlbGroup) Apply(d *data) error {
 	dir, err := d.join("hugetlb")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -19,7 +19,10 @@ type MemoryGroup struct {
 
 func (s *MemoryGroup) Apply(d *data) error {
 	path, err := d.path("memory")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 	if err := os.MkdirAll(path, 0755); err != nil && !os.IsExist(err) {

--- a/cgroups/fs/net_cls.go
+++ b/cgroups/fs/net_cls.go
@@ -10,7 +10,10 @@ type NetClsGroup struct {
 
 func (s *NetClsGroup) Apply(d *data) error {
 	dir, err := d.join("net_cls")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 

--- a/cgroups/fs/net_prio.go
+++ b/cgroups/fs/net_prio.go
@@ -10,7 +10,10 @@ type NetPrioGroup struct {
 
 func (s *NetPrioGroup) Apply(d *data) error {
 	dir, err := d.join("net_prio")
-	if err != nil && !cgroups.IsNotFound(err) {
+	if err != nil {
+		if cgroups.IsNotFound(err) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
If a configuration option is set for a cgroup that isn't mounted, an
error will be emitted. This is an issue, because newer cgroups aren't
present in older kernels, and we can't break backcompat where a new
config can't run on an older kernel.

The issue arises because .Set() does no checks for whether the given
path actually points to a mountpoint, so fix the code by just bailing if
the cgroup mountpoint doesn't exist.

Fixes: fc3981ea5c10
Fixes: 606d9064b0a6
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

This was already done in 606d9064b0a6, and then reverted in fc3981ea5c10. ~~I could not find a related PR to explain why the reversion was done~~, but this is an issue I'm facing when testing a new `cgroup/fs` I'm writing, where the kernel doesn't support it but the config is also non-default.