### PR TITLE
Introduce writeFileInt() to simplify code

### DIFF
--- a/cgroups/fs/apply_raw.go
+++ b/cgroups/fs/apply_raw.go
@@ -271,7 +271,7 @@ func (raw *data) join(subsystem string) (string, error) {
 	if err := os.MkdirAll(path, 0755); err != nil && !os.IsExist(err) {
 		return "", err
 	}
-	if err := writeFile(path, CgroupProcesses, strconv.Itoa(raw.pid)); err != nil {
+	if err := writeFileInt(path, CgroupProcesses, int64(raw.pid)); err != nil {
 		return "", err
 	}
 	return path, nil
@@ -284,6 +284,10 @@ func writeFile(dir, file, data string) error {
 		return fmt.Errorf("no such directory for %s.", file)
 	}
 	return ioutil.WriteFile(filepath.Join(dir, file), []byte(data), 0700)
+}
+
+func writeFileInt(dir, file string, data int64) error {
+	return writeFile(dir, file, strconv.FormatInt(data, 10))
 }
 
 func readFile(dir, file string) (string, error) {

--- a/cgroups/fs/blkio.go
+++ b/cgroups/fs/blkio.go
@@ -32,7 +32,7 @@ func (s *BlkioGroup) Apply(d *data) error {
 
 func (s *BlkioGroup) Set(path string, cgroup *configs.Cgroup) error {
 	if cgroup.BlkioWeight != 0 {
-		if err := writeFile(path, "blkio.weight", strconv.FormatInt(cgroup.BlkioWeight, 10)); err != nil {
+		if err := writeFileInt(path, "blkio.weight", cgroup.BlkioWeight); err != nil {
 			return err
 		}
 	}

--- a/cgroups/fs/cpu.go
+++ b/cgroups/fs/cpu.go
@@ -6,7 +6,6 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/docker/libcontainer/cgroups"
 	"github.com/docker/libcontainer/configs"
@@ -32,27 +31,27 @@ func (s *CpuGroup) Apply(d *data) error {
 
 func (s *CpuGroup) Set(path string, cgroup *configs.Cgroup) error {
 	if cgroup.CpuShares != 0 {
-		if err := writeFile(path, "cpu.shares", strconv.FormatInt(cgroup.CpuShares, 10)); err != nil {
+		if err := writeFileInt(path, "cpu.shares", cgroup.CpuShares); err != nil {
 			return err
 		}
 	}
 	if cgroup.CpuPeriod != 0 {
-		if err := writeFile(path, "cpu.cfs_period_us", strconv.FormatInt(cgroup.CpuPeriod, 10)); err != nil {
+		if err := writeFileInt(path, "cpu.cfs_period_us", cgroup.CpuPeriod); err != nil {
 			return err
 		}
 	}
 	if cgroup.CpuQuota != 0 {
-		if err := writeFile(path, "cpu.cfs_quota_us", strconv.FormatInt(cgroup.CpuQuota, 10)); err != nil {
+		if err := writeFileInt(path, "cpu.cfs_quota_us", cgroup.CpuQuota); err != nil {
 			return err
 		}
 	}
 	if cgroup.CpuRtPeriod != 0 {
-		if err := writeFile(path, "cpu.rt_period_us", strconv.FormatInt(cgroup.CpuRtPeriod, 10)); err != nil {
+		if err := writeFileInt(path, "cpu.rt_period_us", cgroup.CpuRtPeriod); err != nil {
 			return err
 		}
 	}
 	if cgroup.CpuRtRuntime != 0 {
-		if err := writeFile(path, "cpu.rt_runtime_us", strconv.FormatInt(cgroup.CpuRtRuntime, 10)); err != nil {
+		if err := writeFileInt(path, "cpu.rt_runtime_us", cgroup.CpuRtRuntime); err != nil {
 			return err
 		}
 	}

--- a/cgroups/fs/cpuset.go
+++ b/cgroups/fs/cpuset.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/docker/libcontainer/cgroups"
 	"github.com/docker/libcontainer/configs"
@@ -61,7 +60,7 @@ func (s *CpusetGroup) ApplyDir(dir string, cgroup *configs.Cgroup, pid int) erro
 	}
 	// because we are not using d.join we need to place the pid into the procs file
 	// unlike the other subsystems
-	if err := writeFile(dir, "cgroup.procs", strconv.Itoa(pid)); err != nil {
+	if err := writeFileInt(dir, "cgroup.procs", int64(pid)); err != nil {
 		return err
 	}
 

--- a/cgroups/fs/hugetlb.go
+++ b/cgroups/fs/hugetlb.go
@@ -4,7 +4,6 @@ package fs
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/docker/libcontainer/cgroups"
@@ -29,7 +28,7 @@ func (s *HugetlbGroup) Apply(d *data) error {
 
 func (s *HugetlbGroup) Set(path string, cgroup *configs.Cgroup) error {
 	for _, hugetlb := range cgroup.HugetlbLimit {
-		if err := writeFile(path, strings.Join([]string{"hugetlb", hugetlb.Pagesize, "limit_in_bytes"}, "."), strconv.Itoa(hugetlb.Limit)); err != nil {
+		if err := writeFileInt(path, strings.Join([]string{"hugetlb", hugetlb.Pagesize, "limit_in_bytes"}, "."), hugetlb.Limit); err != nil {
 			return err
 		}
 	}

--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/docker/libcontainer/cgroups"
@@ -46,22 +45,22 @@ func (s *MemoryGroup) Apply(d *data) error {
 
 func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 	if cgroup.Memory != 0 {
-		if err := writeFile(path, "memory.limit_in_bytes", strconv.FormatInt(cgroup.Memory, 10)); err != nil {
+		if err := writeFileInt(path, "memory.limit_in_bytes", cgroup.Memory); err != nil {
 			return err
 		}
 	}
 	if cgroup.MemoryReservation != 0 {
-		if err := writeFile(path, "memory.soft_limit_in_bytes", strconv.FormatInt(cgroup.MemoryReservation, 10)); err != nil {
+		if err := writeFileInt(path, "memory.soft_limit_in_bytes", cgroup.MemoryReservation); err != nil {
 			return err
 		}
 	}
 	if cgroup.MemorySwap > 0 {
-		if err := writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(cgroup.MemorySwap, 10)); err != nil {
+		if err := writeFileInt(path, "memory.memsw.limit_in_bytes", cgroup.MemorySwap); err != nil {
 			return err
 		}
 	}
 	if cgroup.KernelMemory > 0 {
-		if err := writeFile(path, "memory.kmem.limit_in_bytes", strconv.FormatInt(cgroup.KernelMemory, 10)); err != nil {
+		if err := writeFileInt(path, "memory.kmem.limit_in_bytes", cgroup.KernelMemory); err != nil {
 			return err
 		}
 	}
@@ -72,7 +71,7 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 		}
 	}
 	if cgroup.MemorySwappiness >= 0 && cgroup.MemorySwappiness <= 100 {
-		if err := writeFile(path, "memory.swappiness", strconv.FormatInt(cgroup.MemorySwappiness, 10)); err != nil {
+		if err := writeFileInt(path, "memory.swappiness", cgroup.MemorySwappiness); err != nil {
 			return err
 		}
 	}

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -293,6 +293,10 @@ func writeFile(dir, file, data string) error {
 	return ioutil.WriteFile(filepath.Join(dir, file), []byte(data), 0700)
 }
 
+func writeFileInt(dir, file string, data int64) error {
+	return writeFile(dir, file, strconv.FormatInt(data, 10))
+}
+
 func join(c *configs.Cgroup, subsystem string, pid int) (string, error) {
 	path, err := getSubsystemPath(c, subsystem)
 	if err != nil {
@@ -301,7 +305,7 @@ func join(c *configs.Cgroup, subsystem string, pid int) (string, error) {
 	if err := os.MkdirAll(path, 0755); err != nil && !os.IsExist(err) {
 		return "", err
 	}
-	if err := writeFile(path, "cgroup.procs", strconv.Itoa(pid)); err != nil {
+	if err := writeFileInt(path, "cgroup.procs", int64(pid)); err != nil {
 		return "", err
 	}
 
@@ -314,22 +318,22 @@ func joinCpu(c *configs.Cgroup, pid int) error {
 		return err
 	}
 	if c.CpuQuota != 0 {
-		if err = writeFile(path, "cpu.cfs_quota_us", strconv.FormatInt(c.CpuQuota, 10)); err != nil {
+		if err = writeFileInt(path, "cpu.cfs_quota_us", c.CpuQuota); err != nil {
 			return err
 		}
 	}
 	if c.CpuPeriod != 0 {
-		if err = writeFile(path, "cpu.cfs_period_us", strconv.FormatInt(c.CpuPeriod, 10)); err != nil {
+		if err = writeFileInt(path, "cpu.cfs_period_us", c.CpuPeriod); err != nil {
 			return err
 		}
 	}
 	if c.CpuRtPeriod != 0 {
-		if err = writeFile(path, "cpu.rt_period_us", strconv.FormatInt(c.CpuRtPeriod, 10)); err != nil {
+		if err = writeFileInt(path, "cpu.rt_period_us", c.CpuRtPeriod); err != nil {
 			return err
 		}
 	}
 	if c.CpuRtRuntime != 0 {
-		if err = writeFile(path, "cpu.rt_runtime_us", strconv.FormatInt(c.CpuRtRuntime, 10)); err != nil {
+		if err = writeFileInt(path, "cpu.rt_runtime_us", c.CpuRtRuntime); err != nil {
 			return err
 		}
 	}
@@ -483,7 +487,7 @@ func setKernelMemory(c *configs.Cgroup) error {
 	}
 
 	if c.KernelMemory > 0 {
-		err = writeFile(path, "memory.kmem.limit_in_bytes", strconv.FormatInt(c.KernelMemory, 10))
+		err = writeFileInt(path, "memory.kmem.limit_in_bytes", c.KernelMemory)
 		if err != nil {
 			return err
 		}
@@ -500,14 +504,14 @@ func joinMemory(c *configs.Cgroup, pid int) error {
 
 	// -1 disables memoryswap
 	if c.MemorySwap > 0 {
-		err = writeFile(path, "memory.memsw.limit_in_bytes", strconv.FormatInt(c.MemorySwap, 10))
+		err = writeFileInt(path, "memory.memsw.limit_in_bytes", c.MemorySwap)
 		if err != nil {
 			return err
 		}
 	}
 
 	if c.MemorySwappiness >= 0 && c.MemorySwappiness <= 100 {
-		err = writeFile(path, "memory.swappiness", strconv.FormatInt(c.MemorySwappiness, 10))
+		err = writeFileInt(path, "memory.swappiness", c.MemorySwappiness)
 		if err != nil {
 			return err
 		}

--- a/configs/hugepage_limit.go
+++ b/configs/hugepage_limit.go
@@ -5,5 +5,5 @@ type HugepageLimit struct {
 	Pagesize string `json:"page_size"`
 
 	// usage limit for hugepage.
-	Limit int `json:"limit"`
+	Limit int64 `json:"limit"`
 }


### PR DESCRIPTION
This makes the code simpler and easier to read.

Also change the type of HugepageLimit.Limit to int64, so it's consistent
with other cgroup config items and can use writeFileInt() without type
conversion.

Signed-of-by: Zefan Li lizefan@huawei.com
