### PR TITLE
Treat -1 as default value for memory swappiness

### DIFF
--- a/cgroups/fs/memory.go
+++ b/cgroups/fs/memory.go
@@ -75,6 +75,10 @@ func (s *MemoryGroup) Set(path string, cgroup *configs.Cgroup) error {
 		if err := writeFile(path, "memory.swappiness", strconv.FormatInt(cgroup.MemorySwappiness, 10)); err != nil {
 			return err
 		}
+	} else if cgroup.MemorySwappiness == -1 {
+		return nil
+	} else {
+		return fmt.Errorf("invalid value:%d. valid memory swappiness range is 0-100", cgroup.MemorySwappiness)
 	}
 
 	return nil

--- a/cgroups/systemd/apply_systemd.go
+++ b/cgroups/systemd/apply_systemd.go
@@ -511,6 +511,10 @@ func joinMemory(c *configs.Cgroup, pid int) error {
 		if err != nil {
 			return err
 		}
+	} else if c.MemorySwappiness == -1 {
+		return nil
+	} else {
+		return fmt.Errorf("invalid value:%d. valid memory swappiness range is 0-100", c.MemorySwappiness)
 	}
 
 	return nil


### PR DESCRIPTION
As mentioned in #639 for some older kernels setting swappiness
fails. This happens even when nobody tries to configure swappiness
from docker UI because we would still get some default value from
host config.
With this we treat -1 value as default value and skip the enforcement
of swappiness.

Signed-off-by: Raghavendra K T raghavendra.kt@linux.vnet.ibm.com
