### PR TITLE
Update utils.go

### DIFF
--- a/cgroups/utils.go
+++ b/cgroups/utils.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/pkg/mount"
-	"github.com/docker/docker/pkg/units"
+	"github.com/docker/go-units"
 )
 
 // https://www.kernel.org/doc/Documentation/cgroups/cgroups.txt


### PR DESCRIPTION
github.com/docker/go-units replaces github.com/docker/docker/pkg/units
